### PR TITLE
Multi peer address advertising/discovery, take 2.

### DIFF
--- a/BreadWallet.xcodeproj/project.pbxproj
+++ b/BreadWallet.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		47EAECE619D8A1F400AC0771 /* BRMultiPeerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 47EAECE519D8A1F400AC0771 /* BRMultiPeerManager.m */; };
 		7525B619192453840041C0F2 /* BRNavigationBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 7525B618192453840041C0F2 /* BRNavigationBar.m */; };
 		752E289A192349CE00DB5A3C /* BreadWallet.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 752E2898192349CE00DB5A3C /* BreadWallet.xcdatamodeld */; };
 		752E28AA19234AE300DB5A3C /* BRAddressEntity.m in Sources */ = {isa = PBXBuildFile; fileRef = 752E289F19234AE300DB5A3C /* BRAddressEntity.m */; };
@@ -697,6 +698,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		47EAECE419D8A1F400AC0771 /* BRMultiPeerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BRMultiPeerManager.h; sourceTree = "<group>"; };
+		47EAECE519D8A1F400AC0771 /* BRMultiPeerManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BRMultiPeerManager.m; sourceTree = "<group>"; };
 		7525B617192453840041C0F2 /* BRNavigationBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BRNavigationBar.h; sourceTree = "<group>"; };
 		7525B618192453840041C0F2 /* BRNavigationBar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BRNavigationBar.m; sourceTree = "<group>"; };
 		752E2899192349CE00DB5A3C /* BreadWallet.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = BreadWallet.xcdatamodel; sourceTree = "<group>"; };
@@ -1678,6 +1681,8 @@
 				752E28BF19234C3600DB5A3C /* BRPaymentProtocol.m */,
 				752E28C019234C3600DB5A3C /* BRPaymentRequest.h */,
 				752E28C119234C3600DB5A3C /* BRPaymentRequest.m */,
+				47EAECE419D8A1F400AC0771 /* BRMultiPeerManager.h */,
+				47EAECE519D8A1F400AC0771 /* BRMultiPeerManager.m */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -3150,7 +3155,7 @@
 				ORGANIZATIONNAME = "Aaron Voisine";
 				TargetAttributes = {
 					75D5F3BD191EC270004AB296 = {
-						DevelopmentTeam = 4R7S6N88W9;
+						DevelopmentTeam = 72D53DS677;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -3161,6 +3166,7 @@
 						};
 					};
 					75D5F3E4191EC270004AB296 = {
+						DevelopmentTeam = 72D53DS677;
 						TestTargetID = 75D5F3BD191EC270004AB296;
 					};
 				};
@@ -3859,6 +3865,7 @@
 				752E28D019234C3600DB5A3C /* BRBloomFilter.m in Sources */,
 				752E28D619234C3600DB5A3C /* BRPeer.m in Sources */,
 				752E28D819234C3600DB5A3C /* BRPeerManager.m in Sources */,
+				47EAECE619D8A1F400AC0771 /* BRMultiPeerManager.m in Sources */,
 				752E28D419234C3600DB5A3C /* BRPaymentProtocol.m in Sources */,
 				752E28D519234C3600DB5A3C /* BRPaymentRequest.m in Sources */,
 				7525B619192453840041C0F2 /* BRNavigationBar.m in Sources */,

--- a/BreadWallet/BRMultiPeerManager.h
+++ b/BreadWallet/BRMultiPeerManager.h
@@ -30,8 +30,8 @@
 
 #define BROWSES YES
 #define DEFAULT_PEER_NAME @"Peer"
-#define SERVICE_TYPE @"bwmulti" // Must be 1–15 characters long Can contain only ASCII lowercase letters, numbers, and hyphens. (Per docs)
-#define SERVICES_KEY @"bwmultiservices"
+#define SERVICE_TYPE @"bitcoin" // Must be 1–15 characters long Can contain only ASCII lowercase letters, numbers, and hyphens. (Per docs)
+#define SERVICES_KEY @"bitcoinservices"
 #define PEER_COUNT_KEY @"peercount"
 #define ADDRESS_KEY @"addr"
 #define DISPLAY_NAME_KEY @"displayname"

--- a/BreadWallet/BRMultiPeerManager.h
+++ b/BreadWallet/BRMultiPeerManager.h
@@ -1,0 +1,62 @@
+//
+//  BRMultiPeerManager.h
+//  BreadWallet
+//
+//  Created by Sheldon Thomas on 9/20/14.
+//  Copyright (c) 2014 Aaron Voisine. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#ifdef MULTIPEER
+
+#import <Foundation/Foundation.h>
+#import <MultipeerConnectivity/MultipeerConnectivity.h>
+
+#define BROWSES YES
+#define DEFAULT_PEER_NAME @"Peer"
+#define SERVICE_TYPE @"bwmulti" // Must be 1–15 characters long Can contain only ASCII lowercase letters, numbers, and hyphens. (Per docs)
+#define SERVICES_KEY @"bwmultiservices"
+#define PEER_COUNT_KEY @"peercount"
+#define ADDRESS_KEY @"addr"
+#define DISPLAY_NAME_KEY @"displayname"
+#define TIME_ENCOUNTERED_KEY @"time"
+#define MINIMUM_PEERS 0
+#define MAXIMUM_PEERS 10
+
+#define BRMultiPeerManagerNewPeerCountNofication @"BRMultiPeerManagerNewPeerCountNofication"
+
+@class BRMultiPeerManager;
+
+@interface BRMultiPeerManager : NSObject
+
+- (instancetype)newPeerName;
+- (void)startAdvertisingWithCompletion:(void (^)(void))completion;
+- (void)stopAdvertisingWithCompletion:(void (^)(void))completion;
+- (void)startBrowsingWithCompletion:(void (^)(void))completion;
+
++ (instancetype)sharedInstance;
+
+@property (nonatomic, strong) NSMutableOrderedSet *peers;
+
+@property (nonatomic, strong, readonly) NSNumber *advertises;
+@property (nonatomic, strong, readonly) MCPeerID *peerID;
+
+@end
+
+#endif

--- a/BreadWallet/BRMultiPeerManager.m
+++ b/BreadWallet/BRMultiPeerManager.m
@@ -1,0 +1,262 @@
+//
+//  BRMultiPeerManager.m
+//  BreadWallet
+//
+//  Created by Sheldon Thomas on 9/20/14.
+//  Copyright (c) 2014 Aaron Voisine. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#ifdef MULTIPEER
+
+#include <stdlib.h>
+
+#import "BRMultiPeerManager.h"
+#import "BRWalletManager.h"
+#import "BRWallet.h"
+
+#define NOISY_MULTIPEERMANAGER NO
+
+typedef enum : uint16_t {
+    BRMultiPeerServiceTypeBitcoinAddressAdvertiser = (1 << 0), // 00000001 => Only advertises recieving addresses, never joins a session
+    BRMultiPeerServiceTypeBitcoinPaymentProtocol = (1 << 1), // 00000010 => For accepting, fufilling, and acknowledging bitcoin payment protocol objects. TODO
+    BRMultiPeerServiceTypeBitcoinNetworkRelay = (1 << 2) // 00000100 => For relaying traffic to the bitcoin network if the other device has connectivity and this does not. TODO
+}BRMultiPeerServiceType;
+
+@interface BRMultiPeerManager() <MCSessionDelegate, MCAdvertiserAssistantDelegate, MCNearbyServiceBrowserDelegate>
+
+@property (nonatomic) BRMultiPeerServiceType serviceType;
+@property (nonatomic, strong) MCSession *session;
+@property (nonatomic, strong) MCAdvertiserAssistant *serviceAdvertiserAssistant;
+@property (nonatomic, strong) MCNearbyServiceBrowser *nearbyServiceBrowser;
+@property (nonatomic, strong) dispatch_queue_t q;
+@property (nonatomic, strong) id seedChangeObserver;
+
+@end
+
+@implementation BRMultiPeerManager
+
+#pragma mark - MCNearbyServiceBrowser
+
+// Used for fully bidirectional sessions
+- (void)session:(MCSession *)session peer:(MCPeerID *)peerID didChangeState:(MCSessionState)state
+{
+    // required delegate method but unused
+}
+
+// Received data from remote peer
+- (void)session:(MCSession *)session didReceiveData:(NSData *)data fromPeer:(MCPeerID *)peerID
+{
+    // required delegate method but unused
+}
+
+// Received a byte stream from remote peer
+- (void)session:(MCSession *)session didReceiveStream:(NSInputStream *)stream withName:(NSString *)streamName fromPeer:(MCPeerID *)peerID
+{
+    // required delegate method but unused
+}
+
+// Start receiving a resource from remote peer
+- (void)session:(MCSession *)session didStartReceivingResourceWithName:(NSString *)resourceName fromPeer:(MCPeerID *)peerID withProgress:(NSProgress *)progress
+{
+    // required delegate method but unused
+}
+
+
+// Finished receiving a resource from remote peer and saved the content in a temporary location - the app is responsible for moving the file to a permanent location within its sandbox
+- (void)session:(MCSession *)session didFinishReceivingResourceWithName:(NSString *)resourceName fromPeer:(MCPeerID *)peerID atURL:(NSURL *)localURL withError:(NSError *)error
+{
+    if (NOISY_MULTIPEERMANAGER) NSLog(@"didFinishReceivingResourceWithName");
+}
+
+// Made first contact with peer and have identity information about the remote peer (certificate may be nil)
+- (void)session:(MCSession *)session didReceiveCertificate:(NSArray *)certificate fromPeer:(MCPeerID *)peerID certificateHandler:(void(^)(BOOL accept))certificateHandler
+{
+    if (NOISY_MULTIPEERMANAGER) NSLog(@"didReceiveCertificate");
+}
+
+/*
+ Peer Sanity Test:
+ 
+    1. Is this peer/address combo already in the peers
+        if yes, return
+    2. Are we currently advertising this same peer ID and address (the framework will give you a callback about yourself if you advertise and browse, :-| very annoying)
+        if yes, return
+    2.1 Is this person advertising our address (or any address in our wallet) with a different peer ID?
+        if yes,
+    3. Iis this person advertising
+    3. Is the peer's ID XXXXXX (a 6 digit number?)
+        if no, return
+    4. Do we have a peer in peers with this ID but a different address?
+        if yes, possible impersonation attack -- drop both the new peer ID and old peer ID
+    5. Do we have a peer in peers with a different ID but this address?
+        if yes, drop the peer with the old ID and add the new ID with the same address as the old one.
+ */
+
+// Found a nearby advertising peer
+- (void)browser:(MCNearbyServiceBrowser *)browser foundPeer:(MCPeerID *)peerID withDiscoveryInfo:(NSDictionary *)info
+{
+    if (NOISY_MULTIPEERMANAGER) NSLog(@"MP Found: %@", peerID.displayName);
+    
+    if (![info objectForKey:ADDRESS_KEY])
+        return;
+    
+    // sanity check 1
+    NSIndexSet* s = [self.peers indexesOfObjectsPassingTest:^BOOL(NSDictionary* obj, NSUInteger idx, BOOL *stop) {
+        if ([[obj objectForKey:ADDRESS_KEY]isEqualToString:[info objectForKey:ADDRESS_KEY]] && [[obj objectForKey:DISPLAY_NAME_KEY]isEqualToString:peerID.displayName])
+            return YES;
+        else
+            return NO;
+    }];
+    if (s.count) return;
+    
+    // sanity check 2
+    if ([[[BRWalletManager sharedInstance] wallet] receiveAddress])
+        if ([self.peerID.displayName isEqualToString:peerID.displayName] && [[[[BRWalletManager sharedInstance] wallet] receiveAddress] isEqualToString:[info objectForKey:ADDRESS_KEY]])
+            return;
+    
+    // sanity check 3
+    if ([[peerID displayName]intValue] == 0 || [[peerID displayName]intValue] == INT_MAX || [[peerID displayName]intValue] == INT_MIN)
+        return;
+    
+    // sanity check 4
+    NSIndexSet* s1 = [self.peers indexesOfObjectsPassingTest:^BOOL(NSDictionary* obj, NSUInteger idx, BOOL *stop) {
+        if ([[obj objectForKey:DISPLAY_NAME_KEY]isEqualToString:[peerID displayName]])
+            return YES;
+        else
+            return NO;
+    }];
+    if (s1.count)
+    {
+        [self.peers removeObjectsAtIndexes:s1];
+        [[NSNotificationCenter defaultCenter]postNotificationName:BRMultiPeerManagerNewPeerCountNofication object:nil userInfo:nil];
+        return;
+    }
+
+    NSIndexSet* s2 = [self.peers indexesOfObjectsPassingTest:^BOOL(NSDictionary* obj, NSUInteger idx, BOOL *stop) {
+        if ([[obj objectForKey:ADDRESS_KEY]isEqualToString:[info objectForKey:ADDRESS_KEY]])
+            return YES;
+        else
+            return NO;
+    }];
+    if (s2.count)
+        [self.peers removeObjectsAtIndexes:s2];
+    // Add the new entry
+    NSMutableDictionary* mutableInfoDictionary = [NSMutableDictionary dictionaryWithDictionary:info];
+    [mutableInfoDictionary setObject:peerID.displayName forKey:DISPLAY_NAME_KEY];
+    [mutableInfoDictionary setObject:[NSDate date] forKey:TIME_ENCOUNTERED_KEY];
+    [self.peers addObject:mutableInfoDictionary];
+    // Post notification
+    [[NSNotificationCenter defaultCenter]postNotificationName:BRMultiPeerManagerNewPeerCountNofication object:nil userInfo:@{PEER_COUNT_KEY:@(self.peers.count)}];
+}
+
+// A nearby peer has stopped advertising
+- (void)browser:(MCNearbyServiceBrowser *)browser lostPeer:(MCPeerID *)peerID
+{
+    if (NOISY_MULTIPEERMANAGER) NSLog(@"MP lost %@", peerID.displayName);
+    NSIndexSet *a = [self.peers indexesOfObjectsPassingTest:^BOOL(NSDictionary* obj, NSUInteger idx, BOOL *stop) {
+        if ([[obj valueForKey:DISPLAY_NAME_KEY] isEqualToString:peerID.displayName])
+            return YES;
+        else
+            return NO;
+    }];
+    [self.peers removeObjectsAtIndexes:a];
+    [[NSNotificationCenter defaultCenter]postNotificationName:BRMultiPeerManagerNewPeerCountNofication object:nil userInfo:@{PEER_COUNT_KEY:@(self.peers.count)}];
+}
+
+// Browsing did not start due to an error
+- (void)browser:(MCNearbyServiceBrowser *)browser didNotStartBrowsingForPeers:(NSError *)error
+{
+    if (NOISY_MULTIPEERMANAGER) NSLog(@"didNotStartBrowsingForPeers");
+}
+
+#pragma mark - BRMultiPeerManager
+
+- (void)startAdvertisingWithCompletion:(void (^)(void))completion
+{
+    dispatch_async(self.q, ^{
+        [self setServiceAdvertiserAssistant:[[MCAdvertiserAssistant alloc]initWithServiceType:SERVICE_TYPE discoveryInfo:@{SERVICES_KEY:@(self.serviceType).stringValue, ADDRESS_KEY:[[[BRWalletManager sharedInstance] wallet] receiveAddress]} session:self.session]];
+        [self.serviceAdvertiserAssistant setDelegate:self];
+        [self.serviceAdvertiserAssistant start];
+        if (completion) dispatch_async(dispatch_get_main_queue(), completion);
+    });
+}
+
+- (void)stopAdvertisingWithCompletion:(void (^)(void))completion
+{
+    dispatch_async(self.q, ^{
+        [self.serviceAdvertiserAssistant stop];
+        [self setServiceAdvertiserAssistant:nil];
+        if (completion) dispatch_async(dispatch_get_main_queue(), completion);
+    });
+}
+
+// never need to stop browsing
+- (void)startBrowsingWithCompletion:(void (^)(void))completion
+{
+    dispatch_async(self.q, ^{
+        [self setNearbyServiceBrowser:[[MCNearbyServiceBrowser alloc]initWithPeer:self.peerID serviceType:SERVICE_TYPE]];
+        [self.nearbyServiceBrowser setDelegate:self];
+        [self.nearbyServiceBrowser startBrowsingForPeers];
+        if (completion) dispatch_async(dispatch_get_main_queue(), completion);
+    });
+}
+
+- (instancetype)newPeerName
+{
+    _peerID = [[MCPeerID alloc]initWithDisplayName:[self newPeerNameString]];
+    [self setSession:[[MCSession alloc]initWithPeer:self.peerID securityIdentity:nil encryptionPreference:MCEncryptionNone]];
+    return self;
+}
+
+- (NSString* )newPeerNameString
+{
+    return [NSString stringWithFormat:@"%@", [@((arc4random() % 9000) + 1000) stringValue]];
+}
+
+- (instancetype)init
+{
+    if (! (self = [super init])) return nil;
+    self.q = dispatch_queue_create("multipeermanager", NULL);
+    [self setServiceType:(BRMultiPeerServiceTypeBitcoinAddressAdvertiser)]; // default, for now
+//    [self setServiceType:(BRMultiPeerServiceTypeBitcoinAddressAdvertiser | BRMultiPeerServiceTypeBitcoinNetworkRelay)]; // 00000101  => how one would advertise multiple services
+    [self setPeers:[NSMutableOrderedSet orderedSetWithCapacity:MAXIMUM_PEERS]];
+    [self newPeerName];
+    self.seedChangeObserver =
+        [[NSNotificationCenter defaultCenter]addObserverForName:BRWalletManagerSeedChangedNotification object:nil queue:nil usingBlock:^(NSNotification *note) {
+            [self newPeerName];
+        }];
+    return self;
+}
+
++ (instancetype)sharedInstance
+{
+    static id singleton = nil;
+    static dispatch_once_t onceToken = 0;
+    
+    dispatch_once(&onceToken, ^{
+        singleton = [self new];
+    });
+    
+    return singleton;
+}
+
+@end
+
+#endif

--- a/BreadWallet/BRReceiveViewController.h
+++ b/BreadWallet/BRReceiveViewController.h
@@ -30,6 +30,7 @@
 MFMessageComposeViewControllerDelegate, MFMailComposeViewControllerDelegate>
 
 - (IBAction)tip:(id)sender;
+- (IBAction)peerLabelTap:(id)sender;
 
 - (void)updateAddress;
 

--- a/BreadWallet/Base.lproj/Main.storyboard
+++ b/BreadWallet/Base.lproj/Main.storyboard
@@ -1076,6 +1076,15 @@
                                     <outletCollection property="gestureRecognizers" destination="oUQ-zV-oxL" appends="YES" id="4re-TV-YSv"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="888888" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" useAutomaticPreferredMaxLayoutWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P30-vp-ewe">
+                                <rect key="frame" x="34" y="188" width="252" height="158"/>
+                                <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="62"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                                <connections>
+                                    <outletCollection property="gestureRecognizers" destination="Ogu-EO-vMb" appends="YES" id="BkL-Xa-la4"/>
+                                </connections>
+                            </label>
                         </subviews>
                         <gestureRecognizers/>
                         <constraints>
@@ -1094,6 +1103,7 @@
                     <extendedEdge key="edgesForExtendedLayout" bottom="YES"/>
                     <connections>
                         <outlet property="addressButton" destination="XV7-2s-hZs" id="jn1-4G-QVT"/>
+                        <outlet property="peerLabel" destination="P30-vp-ewe" id="6w3-9H-0tp"/>
                         <outlet property="qrView" destination="PTm-4L-adQ" id="Ti4-bc-a9W"/>
                     </connections>
                 </viewController>
@@ -1112,6 +1122,11 @@
                 <tapGestureRecognizer id="wBJ-0U-BOy">
                     <connections>
                         <action selector="tip:" destination="XLw-gP-lYw" id="mfR-zP-xd3"/>
+                    </connections>
+                </tapGestureRecognizer>
+                <tapGestureRecognizer id="Ogu-EO-vMb">
+                    <connections>
+                        <action selector="peerLabelTap:" destination="XLw-gP-lYw" id="JyA-ah-z7Y"/>
                     </connections>
                 </tapGestureRecognizer>
             </objects>
@@ -1168,6 +1183,32 @@
                                     <action selector="scanQR:" destination="RsQ-W7-grB" eventType="touchUpInside" id="wbh-n6-WR8"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zgn-mo-aUf">
+                                <rect key="frame" x="45" y="400" width="230" height="44"/>
+                                <gestureRecognizers/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="06q-6w-h3J"/>
+                                    <constraint firstAttribute="width" constant="230" id="tyQ-G6-MGQ"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="17"/>
+                                <inset key="imageEdgeInsets" minX="-10" minY="0.0" maxX="10" maxY="0.0"/>
+                                <size key="titleShadowOffset" width="0.0" height="1"/>
+                                <state key="normal" title="pay to: " backgroundImage="button-bg-blue">
+                                    <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleShadowColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <state key="disabled" image="cameraguide-small" backgroundImage="button-bg-blue-pressed">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                </state>
+                                <state key="highlighted" image="cameraguide-small" backgroundImage="button-bg-blue-pressed">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="payToPin:" destination="RsQ-W7-grB" eventType="touchUpInside" id="WIc-pk-iaO"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bfj-xS-5rN">
                                 <rect key="frame" x="45" y="334" width="230" height="44"/>
                                 <gestureRecognizers/>
@@ -1221,6 +1262,7 @@
                     <connections>
                         <outlet property="clipboardButton" destination="bfj-xS-5rN" id="mfH-NX-2iX"/>
                         <outlet property="clipboardText" destination="SgP-DR-cyl" id="pL2-sH-61L"/>
+                        <outlet property="multiPeerPayButton" destination="Zgn-mo-aUf" id="a7I-b8-ss1"/>
                         <outlet property="scanButton" destination="ce6-Wi-wk4" id="tr9-fj-NRa"/>
                         <outlet property="sendLabel" destination="l5l-JR-LKA" id="uWh-qp-akV"/>
                     </connections>


### PR DESCRIPTION
Fresh implementation of the discussion here https://github.com/voisine/breadwallet/pull/84

Using ruleset as discussed for ending sessions, and handling duplicate peers broadcasting the same peerid or address. A sanity ruleset is outline and implemented in on line 112 of BRMultiPeerManager.m

Closing the other pull request to move discussion here. 