### PR TITLE
KV Store

### DIFF
--- a/BreadWallet.xcodeproj/project.pbxproj
+++ b/BreadWallet.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		229279A11C695D7900C98E78 /* BRBSPatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229279A01C695D7900C98E78 /* BRBSPatch.swift */; };
 		229279A51C695DE700C98E78 /* BRAPIProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229279A41C695DE700C98E78 /* BRAPIProxy.swift */; };
 		229279A81C6960FC00C98E78 /* BRGeoLocationPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229279A71C6960FC00C98E78 /* BRGeoLocationPlugin.swift */; };
+		2299CF371D5C0D0B0055EA28 /* BRReplicatedKVStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2299CF361D5C0D0B0055EA28 /* BRReplicatedKVStore.swift */; };
+		2299CF391D5C32B70055EA28 /* BRReplicatedKVStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2299CF381D5C32B70055EA28 /* BRReplicatedKVStoreTests.swift */; };
 		22B6A4481C0E963900673913 /* libbz2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 22B6A4471C0E963900673913 /* libbz2.tbd */; };
 		22B6A44A1C0ECB7800673913 /* BRBSPatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B6A4491C0ECB7800673913 /* BRBSPatchTests.swift */; };
 		22BF17471CDF831800AA41C6 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BF17461CDF831800AA41C6 /* Extensions.swift */; };
@@ -233,6 +235,8 @@
 		229279A01C695D7900C98E78 /* BRBSPatch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRBSPatch.swift; sourceTree = "<group>"; };
 		229279A41C695DE700C98E78 /* BRAPIProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRAPIProxy.swift; sourceTree = "<group>"; };
 		229279A71C6960FC00C98E78 /* BRGeoLocationPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRGeoLocationPlugin.swift; sourceTree = "<group>"; };
+		2299CF361D5C0D0B0055EA28 /* BRReplicatedKVStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRReplicatedKVStore.swift; sourceTree = "<group>"; };
+		2299CF381D5C32B70055EA28 /* BRReplicatedKVStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRReplicatedKVStoreTests.swift; sourceTree = "<group>"; };
 		22B6A4471C0E963900673913 /* libbz2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbz2.tbd; path = usr/lib/libbz2.tbd; sourceTree = SDKROOT; };
 		22B6A4491C0ECB7800673913 /* BRBSPatchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRBSPatchTests.swift; sourceTree = "<group>"; };
 		22BF17461CDF831800AA41C6 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
@@ -560,6 +564,7 @@
 				220128D41C76E1550001CAC1 /* BRWebSocket.swift */,
 				229279A61C6960B200C98E78 /* HTTP Plugins */,
 				222040C31C1A0903005CE1C3 /* BRWebViewController.swift */,
+				2299CF361D5C0D0B0055EA28 /* BRReplicatedKVStore.swift */,
 			);
 			name = AppRuntime;
 			sourceTree = "<group>";
@@ -895,6 +900,7 @@
 				22FCD22B1C0E68C80066D798 /* BRTarTests.swift */,
 				22B6A4491C0ECB7800673913 /* BRBSPatchTests.swift */,
 				222040C71C1A3803005CE1C3 /* BRHTTPServerTests.swift */,
+				2299CF381D5C32B70055EA28 /* BRReplicatedKVStoreTests.swift */,
 				75CE50B51B5216F100DBC18C /* Info.plist */,
 				75EDC0E71CD92EA90090B838 /* BreadWalletTests-Bridging-Header.h */,
 			);
@@ -1343,6 +1349,7 @@
 				220128D31C753C670001CAC1 /* BRSocketHelpers.c in Sources */,
 				752E28E919234DA200DB5A3C /* NSManagedObject+Sugar.m in Sources */,
 				BA7B53541BDAA0A800355E8D /* BRAppleWatchTransactionData.m in Sources */,
+				2299CF371D5C0D0B0055EA28 /* BRReplicatedKVStore.swift in Sources */,
 				751B2B5C1B68911700EA87FB /* BRTxHistoryViewController.m in Sources */,
 				752E28EA19234DA200DB5A3C /* NSMutableData+Bitcoin.m in Sources */,
 				752E28EB19234DA200DB5A3C /* NSString+Bitcoin.m in Sources */,
@@ -1363,6 +1370,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				22DE8CF31D02407F007F07F3 /* BRWalletConstants.m in Sources */,
+				2299CF391D5C32B70055EA28 /* BRReplicatedKVStoreTests.swift in Sources */,
 				222040C81C1A3803005CE1C3 /* BRHTTPServerTests.swift in Sources */,
 				75D5F3F3191EC270004AB296 /* BreadWalletTests.m in Sources */,
 				22FCD22C1C0E68C80066D798 /* BRTarTests.swift in Sources */,

--- a/BreadWallet/BRAPIClient.swift
+++ b/BreadWallet/BRAPIClient.swift
@@ -536,7 +536,7 @@ func httpDateNow() -> String {
             guard let curBundleContents = NSData(contentsOfFile: bundlePath) else {
                 return handler(error: NSLocalizedString("error reading current bundle", comment: "")) }
             
-            let curBundleSha = NSData(UInt256: curBundleContents.SHA256())!.hexString
+            let curBundleSha = NSData(UInt256: curBundleContents.SHA256()).hexString
             
             dataTaskWithRequest(NSURLRequest(URL: url("/assets/bundles/\(bundleName)/versions")))
                 { (data, resp, err) -> Void in
@@ -599,7 +599,7 @@ func httpDateNow() -> String {
             log("bundle \(bundleName) doesn't exist, downloading new copy")
             let req = NSURLRequest(URL: url("/assets/bundles/\(bundleName)/download"))
             dataTaskWithRequest(req) { (data, response, err) -> Void in
-                if err != nil {
+                if err != nil || response?.statusCode != 200 {
                     return handler(error: NSLocalizedString("error fetching bundle: ", comment: "") + "\(err)")
                 }
                 if let data = data {

--- a/BreadWallet/BRAPIClient.swift
+++ b/BreadWallet/BRAPIClient.swift
@@ -136,7 +136,7 @@ func buildRequestSigningString(r: NSMutableURLRequest) -> String {
     ]
     switch r.HTTPMethod {
     case "POST", "PUT", "PATCH":
-        if let d = r.HTTPBody {
+        if let d = r.HTTPBody where d.length > 0 {
             let sha = d.SHA256()
             parts[1] = NSData(UInt256: sha).base58String()
         }

--- a/BreadWallet/BRAPIClient.swift
+++ b/BreadWallet/BRAPIClient.swift
@@ -45,6 +45,15 @@ let BRAPIClientErrorDomain = "BRApiClientErrorDomain"
 public typealias URLSessionTaskHandler = (NSData?, NSHTTPURLResponse?, NSError?) -> Void
 public typealias URLSessionChallengeHandler = (NSURLSessionAuthChallengeDisposition, NSURLCredential?) -> Void
 
+// an object which implements BRAPIAdaptor can execute API Requests on the current wallet's behalf
+public protocol BRAPIAdaptor {
+    // execute an API request against the current wallet
+    func dataTaskWithRequest(
+        request: NSURLRequest, authenticated: Bool, retryCount: Int,
+        handler: URLSessionTaskHandler
+    ) -> NSURLSessionDataTask
+}
+
 extension String {
     static var urlQuoteCharacterSet: NSCharacterSet {
         let cset = NSMutableCharacterSet.URLQueryAllowedCharacterSet().mutableCopy() as! NSMutableCharacterSet
@@ -148,7 +157,7 @@ func httpDateNow() -> String {
     return rfc1123DateFormatter.stringFromDate(NSDate())
 }
 
-@objc public class BRAPIClient: NSObject, NSURLSessionDelegate, NSURLSessionTaskDelegate {
+@objc public class BRAPIClient: NSObject, NSURLSessionDelegate, NSURLSessionTaskDelegate, BRAPIAdaptor {
     var logEnabled = true
     var proto = "https"
     var host = "api.breadwallet.com"
@@ -210,7 +219,7 @@ func httpDateNow() -> String {
         return mutableRequest.copy() as! NSURLRequest
     }
     
-    func dataTaskWithRequest(request: NSURLRequest, authenticated: Bool = false,
+    public func dataTaskWithRequest(request: NSURLRequest, authenticated: Bool = false,
                              retryCount: Int = 0, handler: URLSessionTaskHandler) -> NSURLSessionDataTask {
         let start = NSDate()
         var logLine = ""

--- a/BreadWallet/BRAppDelegate.m
+++ b/BreadWallet/BRAppDelegate.m
@@ -110,6 +110,14 @@
     });
 }
 
+- (void)applicationWillResignActive:(UIApplication *)application
+{
+    BRAPIClient *client = [BRAPIClient sharedClient];
+    [client.kv sync:^(NSError *err) {
+        NSLog(@"Finished syncing. err=%@", err);
+    }];
+}
+
 // Applications may reject specific types of extensions based on the extension point identifier.
 // Constants representing common extension point identifiers are provided further down.
 // If unimplemented, the default behavior is to allow the extension point identifier.

--- a/BreadWallet/BRKey.h
+++ b/BreadWallet/BRKey.h
@@ -58,6 +58,7 @@ int BRSecp256k1PointMul(BRECPoint * _Nonnull p, const UInt256 * _Nonnull i);
 @property (nullable, nonatomic, readonly) NSData *publicKey;
 @property (nullable, nonatomic, readonly) NSString *address;
 @property (nonatomic, readonly) UInt160 hash160;
+@property (nonatomic, readonly) UInt256 secretKey;
 
 + (nullable instancetype)keyWithPrivateKey:(nonnull NSString *)privateKey;
 + (nullable instancetype)keyWithSecret:(UInt256)secret compressed:(BOOL)compressed;

--- a/BreadWallet/BRKey.h
+++ b/BreadWallet/BRKey.h
@@ -58,7 +58,7 @@ int BRSecp256k1PointMul(BRECPoint * _Nonnull p, const UInt256 * _Nonnull i);
 @property (nullable, nonatomic, readonly) NSData *publicKey;
 @property (nullable, nonatomic, readonly) NSString *address;
 @property (nonatomic, readonly) UInt160 hash160;
-@property (nonatomic, readonly) UInt256 secretKey;
+@property (nonatomic, readonly) UInt256 const * _Nullable secretKey;
 
 + (nullable instancetype)keyWithPrivateKey:(nonnull NSString *)privateKey;
 + (nullable instancetype)keyWithSecret:(UInt256)secret compressed:(BOOL)compressed;

--- a/BreadWallet/BRKey.m
+++ b/BreadWallet/BRKey.m
@@ -255,9 +255,9 @@ int BRSecp256k1PointMul(BRECPoint *p, const UInt256 *i)
     return self.publicKey.hash160;
 }
 
-- (UInt256)secretKey
+- (UInt256 const * _Nullable)secretKey
 {
-    return _seckey;
+    return &_seckey;
 }
 
 - (NSString *)address

--- a/BreadWallet/BRKey.m
+++ b/BreadWallet/BRKey.m
@@ -255,6 +255,11 @@ int BRSecp256k1PointMul(BRECPoint *p, const UInt256 *i)
     return self.publicKey.hash160;
 }
 
+- (UInt256)secretKey
+{
+    return _seckey;
+}
+
 - (NSString *)address
 {
     NSMutableData *d = [NSMutableData secureDataWithCapacity:160/8 + 1];

--- a/BreadWallet/BRReplicatedKVStore.swift
+++ b/BreadWallet/BRReplicatedKVStore.swift
@@ -1,0 +1,201 @@
+//
+//  BRReplicatedKVStore.swift
+//  BreadWallet
+//
+//  Created by Samuel Sutch on 8/10/16.
+//  Copyright © 2016 Aaron Voisine. All rights reserved.
+//
+
+import Foundation
+
+enum BRReplicatedKVStoreError: ErrorType {
+    case SQLiteError
+}
+
+
+public class BRReplicatedKVStore {
+    var db: COpaquePointer = nil
+    
+    var path: NSURL {
+        let fm = NSFileManager.defaultManager()
+        let docsUrl = fm.URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask).first!
+        let bundleDirUrl = docsUrl.URLByAppendingPathComponent("kvstore.sqlite3")
+        return bundleDirUrl
+    }
+    
+    init() throws {
+        db = try openDatabase()
+        try migrateDatabase()
+    }
+    
+    public func rmdb() throws {
+        try checkErr(sqlite3_close(db), s: "rmdb - close")
+        try NSFileManager.defaultManager().removeItemAtURL(path)
+    }
+    
+    func openDatabase() throws -> COpaquePointer {
+        var dd: COpaquePointer = nil
+        try checkErr(sqlite3_open(path.absoluteString, &dd), s: "opening db")
+        log("opened DB at \(path.absoluteString)")
+        return dd
+    }
+    
+    func migrateDatabase() throws {
+        let commands = [
+            "CREATE TABLE IF NOT EXISTS dbversion (ver INT NOT NULL PRIMARY KEY ON CONFLICT REPLACE);",
+            "INSERT INTO dbversion (ver) VALUES (1);",
+            "CREATE TABLE IF NOT EXISTS kvstore (" +
+            "   version BIGINT  NOT NULL, " +
+            "   key     TEXT    NOT NULL, " +
+            "   value   BLOB    NOT NULL, " +
+            "   thetime BIGINT  NOT NULL, " + // server unix timestamp in MS
+            "   deleted BOOL    NOT NULL, " +
+            "   PRIMARY KEY (key, version) " +
+            ")"
+        ];
+        for cmd in commands {
+            var cts: COpaquePointer = nil
+            defer {
+                sqlite3_finalize(cts)
+            }
+            try checkErr(sqlite3_prepare_v2(db, cmd, -1, &cts, nil), s: "migrate prepare")
+            try checkErr(sqlite3_step(cts), s: "migrate stmt exec")
+        }
+    }
+    
+    func get(key: String) throws -> (UInt64, NSDate, Bool, [UInt8]) {
+        var ret = [UInt8]()
+        var curVer: UInt64 = 0
+        var deleted = false
+        var time = NSDate()
+        try txn({
+            curVer = try self.localVersion(key)
+            self.log("GET key: \(key) ver: \(curVer)")
+            var stmt: COpaquePointer = nil
+            defer {
+                sqlite3_finalize(stmt)
+            }
+            try self.checkErr(sqlite3_prepare_v2(
+                self.db, "SELECT value, length(value), thetime, deleted FROM kvstore WHERE key=? AND version=? LIMIT 1", -1, &stmt, nil
+            ), s: "get - prepare stmt")
+            sqlite3_bind_text(stmt, 1, NSString(string: key).UTF8String, -1, nil)
+            sqlite3_bind_int64(stmt, 2, Int64(curVer))
+            try self.checkErr(sqlite3_step(stmt), s: "get - step stmt", r: SQLITE_ROW)
+            let blob = sqlite3_column_blob(stmt, 0)
+            let blobLength = sqlite3_column_int(stmt, 1)
+            time = NSDate(timeIntervalSince1970: Double(sqlite3_column_int64(stmt, 2))/1000.0)
+            deleted = sqlite3_column_int(stmt, 3) > 0
+            ret = Array(UnsafeBufferPointer<UInt8>(start: UnsafePointer(blob), count: Int(blobLength)))
+        })
+        return (curVer, time, deleted, ret)
+    }
+    
+    func set(key: String, value: [UInt8], encrypted: Bool = false) throws -> (UInt64, NSDate) {
+        var newVer: UInt64 = 0
+        var time = NSDate(timeIntervalSince1970: Double(Int64(NSDate().timeIntervalSince1970*1000)))
+        try txn({ 
+            let curVer = try self.localVersion(key)
+            self.log("SET key: \(key) ver: \(curVer)")
+            newVer = curVer + 1
+            var stmt: COpaquePointer = nil
+            defer {
+                sqlite3_finalize(stmt)
+            }
+            try self.checkErr(sqlite3_prepare_v2(self.db,
+                "INSERT INTO kvstore (version, key, value, thetime, deleted) " +
+                "VALUES (?, ?, ?, ?, ?)", -1, &stmt, nil
+            ), s: "set - prepare stmt")
+            sqlite3_bind_int64(stmt, 1, Int64(newVer))
+            sqlite3_bind_text(stmt, 2, NSString(string: key).UTF8String, -1, nil)
+            sqlite3_bind_blob(stmt, 3, value, Int32(value.count), nil)
+            sqlite3_bind_int64(stmt, 4, Int64(time.timeIntervalSince1970*1000))
+            sqlite3_bind_int(stmt, 5, 0)
+            try self.checkErr(sqlite3_step(stmt), s: "set - step stmt")
+        })
+        syncKey(key) { 
+            self.log("key synced: \(key)")
+        }
+        return (newVer, time)
+    }
+    
+    func del(key: String) throws -> (UInt64, NSDate) {
+        var newVer: UInt64 = 0
+        var time = NSDate(timeIntervalSince1970: Double(Int64(NSDate().timeIntervalSince1970*1000)))
+        try txn({ 
+            let curVer = try self.localVersion(key)
+            self.log("DEL key: \(key) ver: \(curVer)")
+            newVer = curVer + 1
+            var stmt: COpaquePointer = nil
+            defer {
+                sqlite3_finalize(stmt)
+            }
+            try self.checkErr(sqlite3_prepare_v2(
+                self.db, "INSERT INTO kvstore (version, key, value, thetime, deleted) " +
+                         "SELECT ?, key, value, ?, ? " +
+                         "FROM kvstore WHERE key=? AND version=? ORDER BY version DESC LIMIT 1",
+                -1, &stmt, nil
+            ), s: "del - prepare stmt")
+            sqlite3_bind_int64(stmt, 1, Int64(newVer))
+            sqlite3_bind_int64(stmt, 2, Int64(time.timeIntervalSince1970*1000))
+            sqlite3_bind_int(stmt, 3, 1)
+            sqlite3_bind_text(stmt, 4, NSString(string: key).UTF8String, -1, nil)
+            sqlite3_bind_int64(stmt, 5, Int64(curVer))
+            try self.checkErr(sqlite3_step(stmt), s: "del - exec stmt")
+        })
+        return (newVer, time)
+    }
+    
+    func localVersion(key: String) throws -> UInt64 {
+        var stmt: COpaquePointer = nil
+        defer {
+            sqlite3_finalize(stmt)
+        }
+        try checkErr(sqlite3_prepare_v2(
+            db, "SELECT version FROM kvstore WHERE key = ? ORDER BY version DESC LIMIT 1", -1, &stmt, nil
+        ), s: "get version - prepare")
+        sqlite3_bind_text(stmt, 1, NSString(string: key).UTF8String, -1, nil)
+        try checkErr(sqlite3_step(stmt), s: "get version - exec", r: SQLITE_ROW)
+        return UInt64(sqlite3_column_int64(stmt, 0))
+    }
+    
+    func syncAllKeys(completionHandler: () -> ()) {
+        
+    }
+    
+    func syncKey(key: String, completionHandler: () -> ()) {
+        
+    }
+    
+    func txn(fn: () throws -> ()) throws {
+        var beginStmt: COpaquePointer = nil
+        var finishStmt: COpaquePointer = nil
+        defer {
+            sqlite3_finalize(beginStmt)
+            sqlite3_finalize(finishStmt)
+        }
+        try checkErr(sqlite3_prepare_v2(db, "BEGIN", -1, &beginStmt, nil), s: "txn - prepare begin")
+        try checkErr(sqlite3_step(beginStmt), s: "txn - exec begin begin")
+        do {
+            try fn()
+        } catch let e {
+            try checkErr(sqlite3_prepare_v2(db, "ROLLBACK" , -1, &finishStmt, nil), s: "txn - prepare rollback")
+            try checkErr(sqlite3_step(finishStmt), s: "txn - execute rollback")
+            throw e
+        }
+        try checkErr(sqlite3_prepare_v2(db, "COMMIT", -1, &finishStmt, nil), s: "txn - prepare commit")
+        try checkErr(sqlite3_step(finishStmt), s: "txn - execute commit")
+    }
+    
+    func checkErr(e: Int32, s: String, r: Int32 = SQLITE_NULL) throws {
+        if (r == SQLITE_NULL && (e != SQLITE_OK && e != SQLITE_DONE && e != SQLITE_ROW)) && (e != SQLITE_NULL && e != r) {
+            let es = NSString(CString: sqlite3_errstr(e), encoding: NSUTF8StringEncoding)
+            let em = NSString(CString: sqlite3_errmsg(db), encoding: NSUTF8StringEncoding)
+            log("\(s): errcode=\(e) errstr=\(es) errmsg=\(em)")
+            throw BRReplicatedKVStoreError.SQLiteError
+        }
+    }
+    
+    func log(s: String) {
+        print("[KVStore]: \(s)")
+    }
+}

--- a/BreadWallet/BRReplicatedKVStore.swift
+++ b/BreadWallet/BRReplicatedKVStore.swift
@@ -199,22 +199,20 @@ public class BRReplicatedKVStore {
     }
     
     func encrypt(data: [UInt8]) throws -> [UInt8] {
-        var sec = key.secretKey
         let inData = UnsafePointer<UInt8>(data)
         let nonce = genNonce()
-        let outSize = chacha20Poly1305AEADEncrypt(nil, 0, &sec, nonce, inData, data.count, nil, 0)
+        let outSize = chacha20Poly1305AEADEncrypt(nil, 0, key.secretKey, nonce, inData, data.count, nil, 0)
         var outData = [UInt8](count: outSize, repeatedValue: 0)
-        chacha20Poly1305AEADEncrypt(&outData, outSize, &sec, nonce, inData, data.count, nil, 0)
+        chacha20Poly1305AEADEncrypt(&outData, outSize, key.secretKey, nonce, inData, data.count, nil, 0)
         return nonce + outData
     }
     
     func decrypt(data: [UInt8]) throws -> [UInt8] {
-        var sec = key.secretKey
         let nonce = Array(data[data.startIndex...data.startIndex.advancedBy(12)])
         let inData = Array(data[data.startIndex.advancedBy(12)...(data.endIndex-1)])
-        let outSize = chacha20Poly1305AEADDecrypt(nil, 0, &sec, nonce, inData, inData.count, nil, 0)
+        let outSize = chacha20Poly1305AEADDecrypt(nil, 0, key.secretKey, nonce, inData, inData.count, nil, 0)
         var outData = [UInt8](count: outSize, repeatedValue: 0)
-        chacha20Poly1305AEADDecrypt(&outData, outSize, &sec, nonce, inData, inData.count, nil, 0)
+        chacha20Poly1305AEADDecrypt(&outData, outSize, key.secretKey, nonce, inData, inData.count, nil, 0)
         return outData
     }
     

--- a/BreadWallet/BRReplicatedKVStore.swift
+++ b/BreadWallet/BRReplicatedKVStore.swift
@@ -3,8 +3,26 @@
 //  BreadWallet
 //
 //  Created by Samuel Sutch on 8/10/16.
-//  Copyright © 2016 Aaron Voisine. All rights reserved.
+//  Copyright © 2016 breadwallet LLC. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
 
 import Foundation
 

--- a/BreadWallet/BRReplicatedKVStore.swift
+++ b/BreadWallet/BRReplicatedKVStore.swift
@@ -8,14 +8,35 @@
 
 import Foundation
 
-enum BRReplicatedKVStoreError: ErrorType {
+public enum BRReplicatedKVStoreError: ErrorType {
     case SQLiteError
+    case ReplicationError
+    case AlreadyReplicating
+    case Conflict
+    case NotFound
+    case Unknown
 }
 
+public enum BRRemoteKVStoreError: ErrorType {
+    case NotFound
+    case Conflict
+    case Tombstone
+    case Unknown
+}
+
+public protocol BRRemoteKVStoreAdaptor {
+    func ver(key: String, completionFunc: (UInt64, NSDate, BRRemoteKVStoreError?) -> ())
+    func put(key: String, value: [UInt8], version: UInt64, completionFunc: (UInt64, NSDate, BRRemoteKVStoreError?) -> ())
+    func del(key: String, version: UInt64, completionFunc: (UInt64, NSDate, BRRemoteKVStoreError?) -> ())
+    func get(key: String, version: UInt64, completionFunc: (UInt64, NSDate, [UInt8], BRRemoteKVStoreError?) -> ())
+    func keys(completionFunc: ([(String, UInt64, NSDate, BRRemoteKVStoreError?)], BRRemoteKVStoreError?) -> ())
+}
 
 public class BRReplicatedKVStore {
-    var db: COpaquePointer = nil
+    var db: COpaquePointer = nil // sqlite3*
     var key: BRKey
+    var remote: BRRemoteKVStoreAdaptor
+    var syncRunning = false
     
     var path: NSURL {
         let fm = NSFileManager.defaultManager()
@@ -24,8 +45,9 @@ public class BRReplicatedKVStore {
         return bundleDirUrl
     }
     
-    init(encryptionKey: BRKey) throws {
+    init(encryptionKey: BRKey, remoteAdaptor: BRRemoteKVStoreAdaptor) throws {
         key = encryptionKey
+        remote = remoteAdaptor
         db = try openDatabase()
         try migrateDatabase()
     }
@@ -47,13 +69,14 @@ public class BRReplicatedKVStore {
             "CREATE TABLE IF NOT EXISTS dbversion (ver INT NOT NULL PRIMARY KEY ON CONFLICT REPLACE);",
             "INSERT INTO dbversion (ver) VALUES (1);",
             "CREATE TABLE IF NOT EXISTS kvstore (" +
-            "   version BIGINT  NOT NULL, " +
-            "   key     TEXT    NOT NULL, " +
-            "   value   BLOB    NOT NULL, " +
-            "   thetime BIGINT  NOT NULL, " + // server unix timestamp in MS
-            "   deleted BOOL    NOT NULL, " +
+            "   version         BIGINT  NOT NULL, " +
+            "   remote_version  BIGINT  NOT NULL DEFAULT 0, " +
+            "   key             TEXT    NOT NULL, " +
+            "   value           BLOB    NOT NULL, " +
+            "   thetime         BIGINT  NOT NULL, " + // server unix timestamp in MS
+            "   deleted         BOOL    NOT NULL, " +
             "   PRIMARY KEY (key, version) " +
-            ")"
+            ");"
         ];
         for cmd in commands {
             var cts: COpaquePointer = nil
@@ -65,20 +88,43 @@ public class BRReplicatedKVStore {
         }
     }
     
-    func get(key: String) throws -> (UInt64, NSDate, Bool, [UInt8]) {
+    // get a key from the local database, optionally specifying a version
+    func get(key: String, version: UInt64 = 0) throws -> (UInt64, NSDate, Bool, [UInt8]) {
         var ret = [UInt8]()
         var curVer: UInt64 = 0
         var deleted = false
         var time = NSDate()
         try txn({
-            curVer = try self.localVersion(key)
+            if version == 0 {
+                (curVer, _) = try self.localVersion(key)
+            } else {
+                // check for the existence of such a version
+                var vStmt: COpaquePointer = nil
+                defer {
+                    sqlite3_finalize(vStmt)
+                }
+                try self.checkErr(sqlite3_prepare_v2(
+                    self.db, "SELECT version FROM kvstore WHERE key = ? AND version = ? ORDER BY version DESC LIMIT 1",
+                    -1, &vStmt, nil
+                ), s: "get - get version - prepare")
+                sqlite3_bind_text(vStmt, 1, NSString(string: key).UTF8String, -1, nil)
+                sqlite3_bind_int64(vStmt, 2, Int64(version))
+                try self.checkErr(sqlite3_step(vStmt), s: "get - get version - exec", r: SQLITE_ROW)
+                curVer = UInt64(sqlite3_column_int64(vStmt, 0))
+            }
+            if curVer == 0 {
+                throw BRReplicatedKVStoreError.NotFound
+            }
+            
+            
             self.log("GET key: \(key) ver: \(curVer)")
             var stmt: COpaquePointer = nil
             defer {
                 sqlite3_finalize(stmt)
             }
             try self.checkErr(sqlite3_prepare_v2(
-                self.db, "SELECT value, length(value), thetime, deleted FROM kvstore WHERE key=? AND version=? LIMIT 1", -1, &stmt, nil
+                self.db, "SELECT value, length(value), thetime, deleted FROM kvstore WHERE key=? AND version=? LIMIT 1",
+                -1, &stmt, nil
             ), s: "get - prepare stmt")
             sqlite3_bind_text(stmt, 1, NSString(string: key).UTF8String, -1, nil)
             sqlite3_bind_int64(stmt, 2, Int64(curVer))
@@ -92,11 +138,15 @@ public class BRReplicatedKVStore {
         return (curVer, time, deleted, try decrypt(ret))
     }
     
-    func set(key: String, value: [UInt8]) throws -> (UInt64, NSDate) {
+    // set a key in the database
+    func set(key: String, value: [UInt8], localVer: UInt64) throws -> (UInt64, NSDate) {
         var newVer: UInt64 = 0
         var time = NSDate(timeIntervalSince1970: Double(Int64(NSDate().timeIntervalSince1970*1000)))
-        try txn({ 
-            let curVer = try self.localVersion(key)
+        try txn({
+            let (curVer, _) = try self.localVersion(key)
+            if curVer != localVer {
+                throw BRReplicatedKVStoreError.Conflict
+            }
             self.log("SET key: \(key) ver: \(curVer)")
             newVer = curVer + 1
             let encryptedData = try self.encrypt(value)
@@ -115,17 +165,23 @@ public class BRReplicatedKVStore {
             sqlite3_bind_int(stmt, 5, 0)
             try self.checkErr(sqlite3_step(stmt), s: "set - step stmt")
         })
-        syncKey(key) { 
-            self.log("key synced: \(key)")
+        try syncKey(key) { _ in
+            self.log("SET key synced: \(key)")
         }
         return (newVer, time)
     }
     
-    func del(key: String) throws -> (UInt64, NSDate) {
+    func del(key: String, localVer: UInt64) throws -> (UInt64, NSDate) {
+        if localVer == 0 {
+            throw BRReplicatedKVStoreError.NotFound
+        }
         var newVer: UInt64 = 0
         var time = NSDate(timeIntervalSince1970: Double(Int64(NSDate().timeIntervalSince1970*1000)))
         try txn({ 
-            let curVer = try self.localVersion(key)
+            let (curVer, _) = try self.localVersion(key)
+            if curVer != localVer {
+                throw BRReplicatedKVStoreError.Conflict
+            }
             self.log("DEL key: \(key) ver: \(curVer)")
             newVer = curVer + 1
             var stmt: COpaquePointer = nil
@@ -145,28 +201,276 @@ public class BRReplicatedKVStore {
             sqlite3_bind_int64(stmt, 5, Int64(curVer))
             try self.checkErr(sqlite3_step(stmt), s: "del - exec stmt")
         })
+        try syncKey(key) { _ in
+            self.log("DEL key synced: \(key)")
+        }
         return (newVer, time)
     }
     
-    func localVersion(key: String) throws -> UInt64 {
+    func localVersion(key: String) throws -> (UInt64, NSDate) {
         var stmt: COpaquePointer = nil
         defer {
             sqlite3_finalize(stmt)
         }
         try checkErr(sqlite3_prepare_v2(
-            db, "SELECT version FROM kvstore WHERE key = ? ORDER BY version DESC LIMIT 1", -1, &stmt, nil
+            db, "SELECT version, thetime FROM kvstore WHERE key = ? ORDER BY version DESC LIMIT 1", -1, &stmt, nil
         ), s: "get version - prepare")
         sqlite3_bind_text(stmt, 1, NSString(string: key).UTF8String, -1, nil)
         try checkErr(sqlite3_step(stmt), s: "get version - exec", r: SQLITE_ROW)
+        return (UInt64(sqlite3_column_int64(stmt, 0)), NSDate(timeIntervalSince1970: sqlite3_column_double(stmt, 1)))
+    }
+    
+    func remoteVersion(key: String) throws -> UInt64 {
+        var stmt: COpaquePointer = nil
+        defer {
+            sqlite3_finalize(stmt)
+        }
+        try checkErr(sqlite3_prepare_v2(
+            db, "SELECT remote_version FROM kvstore WHERE key = ? ORDER BY version DESC LIMIT 1", -1, &stmt, nil
+            ), s: "get remote version - prepare")
+        sqlite3_bind_text(stmt, 1, NSString(string: key).UTF8String, -1, nil)
+        try checkErr(sqlite3_step(stmt), s: "get remote version - exec", r: SQLITE_ROW)
         return UInt64(sqlite3_column_int64(stmt, 0))
     }
     
-    func syncAllKeys(completionHandler: () -> ()) {
-        
+    func setRemoteVersion(key: String, localVer: UInt64, remoteVer: UInt64) throws -> (UInt64, NSDate) {
+        var newVer: UInt64 = 0
+        var time = NSDate(timeIntervalSince1970: Double(Int64(NSDate().timeIntervalSince1970*1000)))
+        try txn {
+            let (locV, _) = try self.localVersion(key)
+            if locV != localVer {
+                throw BRReplicatedKVStoreError.Conflict
+            }
+            self.log("UPDATE REMOTE VERSION: \(key) ver: \(localVer)")
+            newVer = locV + 1
+            var stmt: COpaquePointer = nil
+            defer {
+                sqlite3_finalize(stmt)
+            }
+            try self.checkErr(sqlite3_prepare_v2(
+                self.db, "INSERT INTO kvstore (version, key, value, thetime, deleted, remote_version) " +
+                         "SELECT ?, key, value, ?, deleted, ? " +
+                         "FROM kvstore WHERE key=? AND version=? ORDER BY version DESC LIMIT 1",
+                -1, &stmt, nil
+            ), s: "update remote version - prepare stmt")
+            sqlite3_bind_int64(stmt, 1, Int64(newVer))
+            sqlite3_bind_int64(stmt, 2, Int64(time.timeIntervalSince1970*1000))
+            sqlite3_bind_int64(stmt, 3, Int64(remoteVer))
+            sqlite3_bind_text(stmt, 4, NSString(string: key).UTF8String, -1, nil)
+            sqlite3_bind_int64(stmt, 4, Int64(locV))
+            try self.checkErr(sqlite3_step(stmt), s: "update remote - exec stmt")
+        }
+        return (newVer, time)
     }
     
-    func syncKey(key: String, completionHandler: () -> ()) {
+    /// Get a list of (key, localVer, localTime, remoteVer, deleted)
+    func localKeys() throws -> [(String, UInt64, NSDate, UInt64, Bool)] {
+        var stmt: COpaquePointer = nil
+        defer {
+            sqlite3_finalize(stmt)
+        }
+        try self.checkErr(sqlite3_prepare_v2(db,
+            "SELECT kvs.key, kvs.version, kvs.thetime, kvs.remote_version, kvs.deleted " +
+            "FROM kvstore kvs " +
+            "INNER JOIN ( " +
+            "   SELECT MAX(version) AS latest_version, key " +
+            "   FROM kvstore " +
+            "   GROUP BY key " +
+            ") vermax " +
+            "ON kvs.version = vermax.latest_version " +
+            "AND kvs.key = vermax.key", -1, &stmt, nil),
+                          s: "local keys - prepare stmt")
+        var ret = [(String, UInt64, NSDate, UInt64, Bool)]()
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            let key = UnsafePointer<Int8>(sqlite3_column_text(stmt, 0))
+            let ver = sqlite3_column_int64(stmt, 1)
+            let date = sqlite3_column_int64(stmt, 2)
+            let rver = sqlite3_column_int64(stmt, 3)
+            let del = sqlite3_column_int(stmt, 4)
+            ret.append((
+                String.fromCString(key) ?? "",
+                UInt64(ver),
+                NSDate(timeIntervalSince1970: Double(date) / 1000.0),
+                UInt64(rver),
+                del > 0
+            ))
+        }
+        return ret
+    }
+    
+    func syncAllKeys(completionHandler: (BRReplicatedKVStoreError?) -> ()) {
+        // update all keys locally and on the remote server, replacing missing keys
+        //
+        // 1. get a list of all keys from the server
+        // 2. for keys that we don't have, add em
+        // 3. for keys that we do have, sync em
+        // 4. for keys that they don't have that we do, upload em
+        if syncRunning {
+            dispatch_async(dispatch_get_main_queue(), { 
+                completionHandler(.AlreadyReplicating)
+            })
+            return
+        }
+        syncRunning = true
+        let startTime = NSDate()
+        remote.keys { (keyData, err) in
+            if let err = err {
+                self.log("Error fetching remote key data: \(err)")
+                return
+            }
+            self.log("Syncing \(keyData.count) keys")
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)) {
+                var failures = 0
+                var jobs = keyData
+                var concurrency = 0
+                let grp = dispatch_group_create()
+                var runner: () -> () = { }
+                runner = {
+                    if concurrency < 10 && jobs.count > 0 { // run 10 concurrent jobs
+                        runner()
+                    }
+                    if let k = jobs.popLast() {
+                        dispatch_group_enter(grp)
+                        concurrency += 1
+                        dispatch_async(dispatch_get_main_queue()) {
+                            do {
+                                try self.syncKey(k.0, remoteVersion: k.1, remoteTime: k.2, remoteErr: k.3,
+                                    completionHandler: { (err) in
+                                        if err != nil {
+                                            failures += 1
+                                        }
+                                        concurrency -= 1
+                                        dispatch_group_leave(grp)
+                                        runner()
+                                })
+                            } catch {
+                                failures += 1
+                            }
+                            concurrency -= 1
+                            dispatch_group_leave(grp)
+                            runner()
+                        }
+                    }
+                }
+                dispatch_group_wait(grp, DISPATCH_TIME_FOREVER)
+                self.syncRunning = false
+                self.log("Finished syncing in \(NSDate().timeIntervalSinceDate(startTime))")
+            }
+        }
+    }
+    
+    func syncKey(key: String,
+                 remoteVersion: UInt64? = nil, remoteTime: NSDate? = nil, remoteErr: BRRemoteKVStoreError? = nil,
+                 completionHandler: (BRReplicatedKVStoreError?) -> ()) throws {
+        if let RV = remoteVersion, RT = remoteTime {
+            try _syncKey(key, remoteVer: RV, remoteTime: RT, remoteErr: remoteErr, completionHandler: completionHandler)
+        } else {
+            remote.ver(key) { (remoteVer, remoteTime, err) in
+                _ = try? self._syncKey(key, remoteVer: remoteVer, remoteTime: remoteTime, remoteErr: remoteErr,
+                                       completionHandler: completionHandler)
+            }
+        }
+    }
+    
+    // the syncKey kernel - this is provided so syncAllKeys can provide get a bunch of key versions at once
+    // and fan out the _syncKey operations
+    func _syncKey(key: String, remoteVer: UInt64, remoteTime: NSDate, remoteErr: BRRemoteKVStoreError?,
+                  completionHandler: (BRReplicatedKVStoreError?) -> ()) throws {
+        // this is a basic last-write-wins strategy. data loss is possible but in general
+        // we will attempt to sync before making any local modifications to the data
+        // and concurrency will be so low that we don't really need a fancier solution than this.
+        // the strategy is:
+        //
+        // 1. get the remote version. this is our "lock"
+        // 2. along with the remote version will come the last-modified date of the remote object
+        // 3. if their last-modified date is newer than ours, overwrite ours
+        // 4. if their last-modified date is older than ours, overwrite theirs
         
+        // one optimization is we keep the remote version on the most recent local version, if they match,
+        // there is nothing to do
+        if try remoteVersion(key) == remoteVer {
+            completionHandler(nil) // this key is already up to date
+        }
+        
+        let (localVer, localTime, localDeleted, localValue) = try get(key)
+        switch remoteErr {
+        case nil, .Some(.Tombstone):
+            let (lt, rt) = (localTime.timeIntervalSince1970, remoteTime.timeIntervalSince1970)
+            if lt > rt || lt == rt {
+                // local is newer (or a tiebreaker)
+                if localDeleted {
+                    log("Local key \(key) was deleted, removing remotely...")
+                    self.remote.del(key, version: remoteVer, completionFunc: { (newRemoteVer, _, delErr) in
+                        if let delErr = delErr {
+                            self.log("Error deleting remote version for key \(key), error: \(delErr)")
+                            return completionHandler(.ReplicationError)
+                        }
+                        do {
+                            try self.setRemoteVersion(key, localVer: localVer, remoteVer: newRemoteVer)
+                        } catch let e where e is BRReplicatedKVStoreError {
+                            return completionHandler((e as! BRReplicatedKVStoreError))
+                        } catch {
+                            return completionHandler(.ReplicationError)
+                        }
+                        self.log("Local key \(key) removed on server")
+                        completionHandler(nil)
+                    })
+                } else {
+                    log("Local key \(key) is newer, updating remotely...")
+                    self.remote.put(key, value: localValue, version: remoteVer, completionFunc: { (newRemoteVer, _, putErr) in
+                        if let putErr = putErr {
+                            self.log("Error updating remote version for key \(key), error: \(putErr)")
+                            return completionHandler(.ReplicationError)
+                        }
+                        do {
+                            try self.setRemoteVersion(key, localVer: localVer, remoteVer: newRemoteVer)
+                        } catch let e where e is BRReplicatedKVStoreError {
+                            return completionHandler((e as! BRReplicatedKVStoreError))
+                        } catch {
+                            return completionHandler(.ReplicationError)
+                        }
+                        self.log("Local key \(key) updated on server")
+                        completionHandler(nil)
+                    })
+                }
+            } else {
+                // local is out-of-date
+                if remoteErr == .Some(.Tombstone) {
+                    // remote is deleted
+                    log("Remote key \(key) deleted, removing locally")
+                    do {
+                        let (newLocalVer, _) = try self.del(key, localVer: localVer)
+                        try self.setRemoteVersion(key, localVer: newLocalVer, remoteVer: remoteVer)
+                    } catch let e where e is BRReplicatedKVStoreError {
+                        return completionHandler((e as! BRReplicatedKVStoreError))
+                    } catch {
+                        return completionHandler(.ReplicationError)
+                    }
+                } else {
+                    log("Remote key \(key) is newer, fetching...")
+                    // get the remote version
+                    self.remote.get(key, version: remoteVer, completionFunc: { (newRemoteVer, _, remoteData, getErr) in
+                        if let getErr = getErr {
+                            self.log("Error fetching the remote value for key \(getErr), error: \(getErr)")
+                            return completionHandler(.ReplicationError)
+                        }
+                        do {
+                            let (newLocalVer, _) = try self.set(key, value: remoteData, localVer: localVer)
+                            try self.setRemoteVersion(key, localVer: newLocalVer, remoteVer: newRemoteVer)
+                        } catch let e where e is BRReplicatedKVStoreError {
+                            return completionHandler((e as! BRReplicatedKVStoreError))
+                        } catch {
+                            return completionHandler(.ReplicationError)
+                        }
+                        self.log("Updated local key \(key)")
+                        completionHandler(nil)
+                    })
+                }
+            }
+        default:
+            log("Error fetching remote version for key \(key), error: \(remoteErr)")
+            completionHandler(.ReplicationError)
+        }
     }
     
     func txn(fn: () throws -> ()) throws {

--- a/BreadWallet/BRTar.swift
+++ b/BreadWallet/BRTar.swift
@@ -40,6 +40,11 @@ enum BRTarType {
     case Invalid
     
     init(fromData: NSData) {
+        if fromData.length <= 1 {
+            BRTar.log("invalid data")
+            self = Invalid
+            return
+        }
         let byte = UnsafePointer<CChar>(fromData.bytes)[0]
         switch byte {
         case CChar(48): // "0"

--- a/BreadWallet/Extensions.swift
+++ b/BreadWallet/Extensions.swift
@@ -82,3 +82,82 @@ extension String {
         return s
     }
 }
+
+// this is lifted from: https://github.com/Fykec/NSDate-RFC1123/blob/master/NSDate%2BRFC1123.swift
+// Copyright © 2015 Foster Yin. All rights reserved.
+extension NSDate {
+    private static func cachedThreadLocalObjectWithKey<T: AnyObject>(key: String, create: () -> T) -> T {
+        let threadDictionary = NSThread.currentThread().threadDictionary
+        if let cachedObject = threadDictionary[key] as! T? {
+            return cachedObject
+        }
+        else {
+            let newObject = create()
+            threadDictionary[key] = newObject
+            return newObject
+        }
+    }
+    
+    private static func RFC1123DateFormatter() -> NSDateFormatter {
+        return cachedThreadLocalObjectWithKey("RFC1123DateFormatter") {
+            let locale = NSLocale(localeIdentifier: "en_US")
+            let timeZone = NSTimeZone(name: "GMT")
+            let dateFormatter = NSDateFormatter()
+            dateFormatter.locale = locale //need locale for some iOS 9 verision, will not select correct default locale
+            dateFormatter.timeZone = timeZone
+            dateFormatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
+            return dateFormatter
+        }
+    }
+    
+    private static func RFC850DateFormatter() -> NSDateFormatter {
+        return cachedThreadLocalObjectWithKey("RFC850DateFormatter") {
+            let locale = NSLocale(localeIdentifier: "en_US")
+            let timeZone = NSTimeZone(name: "GMT")
+            let dateFormatter = NSDateFormatter()
+            dateFormatter.locale = locale //need locale for some iOS 9 verision, will not select correct default locale
+            dateFormatter.timeZone = timeZone
+            dateFormatter.dateFormat = "EEEE, dd-MMM-yy HH:mm:ss z"
+            return dateFormatter
+        }
+    }
+    
+    private static func asctimeDateFormatter() -> NSDateFormatter {
+        return cachedThreadLocalObjectWithKey("asctimeDateFormatter") {
+            let locale = NSLocale(localeIdentifier: "en_US")
+            let timeZone = NSTimeZone(name: "GMT")
+            let dateFormatter = NSDateFormatter()
+            dateFormatter.locale = locale //need locale for some iOS 9 verision, will not select correct default locale
+            dateFormatter.timeZone = timeZone
+            dateFormatter.dateFormat = "EEE MMM d HH:mm:ss yyyy"
+            return dateFormatter
+        }
+    }
+    
+    static func fromRFC1123(dateString: String) -> NSDate? {
+        
+        var date: NSDate?
+        // RFC1123
+        date = NSDate.RFC1123DateFormatter().dateFromString(dateString)
+        if date != nil {
+            return date
+        }
+        
+        // RFC850
+        date = NSDate.RFC850DateFormatter().dateFromString(dateString)
+        if date != nil {
+            return date
+        }
+        
+        // asctime-date
+        date = NSDate.asctimeDateFormatter().dateFromString(dateString)
+        if date != nil {
+            return date
+        }
+        return nil
+    }
+    
+    func RFC1123String() -> String? {
+        return NSDate.RFC1123DateFormatter().stringFromDate(self)
+    }
+}

--- a/BreadWallet/NSData+Bitcoin.h
+++ b/BreadWallet/NSData+Bitcoin.h
@@ -95,36 +95,40 @@ typedef union _UInt128 {
 #define OP_HASH160     0xa9
 #define OP_CHECKSIG    0xac
 
-void SHA1(void *md, const void *data, size_t len);
-void SHA256(void *md, const void *data, size_t len);
-void SHA512(void *md, const void *data, size_t len);
-void RMD160(void *md, const void *data, size_t len);
-void MD5(void *md, const void *data, size_t len);
-void HMAC(void *md, void (*hash)(void *, const void *, size_t), size_t hlen, const void *key, size_t klen,
-          const void *data, size_t dlen);
-void PBKDF2(void *dk, size_t dklen, void (*hash)(void *, const void *, size_t), size_t hlen,
-            const void *pw, size_t pwlen, const void *salt, size_t slen, unsigned rounds);
+void SHA1(void *_Nonnull md, const void *_Nonnull data, size_t len);
+void SHA256(void *_Nonnull md, const void *_Nonnull data, size_t len);
+void SHA512(void *_Nonnull md, const void *_Nonnull data, size_t len);
+void RMD160(void *_Nonnull md, const void *_Nonnull data, size_t len);
+void MD5(void *_Nonnull md, const void *_Nonnull data, size_t len);
+void HMAC(void *_Nonnull md, void (*_Nonnull hash)(void *_Nonnull , const void *_Nonnull , size_t), size_t hlen,
+          const void *_Nonnull key, size_t klen, const void *_Nonnull data, size_t dlen);
+void PBKDF2(void *_Nonnull dk, size_t dklen, void (*_Nonnull hash)(void *_Nonnull , const void *_Nonnull , size_t),
+            size_t hlen, const void *_Nonnull pw, size_t pwlen, const void *_Nonnull salt, size_t slen,
+            unsigned rounds);
 
 // poly1305 authenticator: https://tools.ietf.org/html/rfc7539
 // must use constant time mem comparison when verifying mac to defend against timing attacks
-void poly1305(void *mac16, const void *key32, const void *data, size_t len);
+void poly1305(void *_Nonnull mac16, const void *_Nonnull key32, const void *_Nonnull data, size_t len);
 
 // chacha20 stream cypher: https://cr.yp.to/chacha.html
-void chacha20(void *out, const void *key32, const void *iv8, const void *data, size_t len, uint64_t counter);
+void chacha20(void *_Nonnull out, const void *_Nonnull key32, const void *_Nonnull iv8, const void *_Nonnull data,
+              size_t len, uint64_t counter);
 
 // chacha20-poly1305 authenticated encryption with associated data (AEAD): https://tools.ietf.org/html/rfc7539
-size_t chacha20Poly1305AEADEncrypt(void *out, size_t outLen, const void *key32, const void *nonce12,
-                                   const void *data, size_t dataLen, const void *ad, size_t adLen);
+size_t chacha20Poly1305AEADEncrypt(void *_Nullable out, size_t outLen, const void *_Nonnull key32,
+                                   const void *_Nonnull nonce12, const void *_Nonnull data, size_t dataLen,
+                                   const void *_Nonnull ad, size_t adLen);
 
-size_t chacha20Poly1305AEADDecrypt(void *out, size_t outLen, const void *key32, const void *nonce12,
-                                   const void *data, size_t dataLen, const void *ad, size_t adLen);
+size_t chacha20Poly1305AEADDecrypt(void *_Nullable out, size_t outLen, const void *_Nonnull key32,
+                                   const void *_Nonnull nonce12, const void *_Nonnull data, size_t dataLen,
+                                   const void *_Nonnull ad, size_t adLen);
 
 @interface NSData (Bitcoin)
 
-+ (instancetype)dataWithUInt256:(UInt256)n;
-+ (instancetype)dataWithUInt160:(UInt160)n;
-+ (instancetype)dataWithUInt128:(UInt128)n;
-+ (instancetype)dataWithBase58String:(NSString *)b58str;
++ (nonnull instancetype)dataWithUInt256:(UInt256)n;
++ (nonnull instancetype)dataWithUInt160:(UInt160)n;
++ (nonnull instancetype)dataWithUInt128:(UInt128)n;
++ (nonnull instancetype)dataWithBase58String:(NSString *_Nonnull)b58str;
 
 - (UInt160)SHA1;
 - (UInt256)SHA256;
@@ -133,20 +137,20 @@ size_t chacha20Poly1305AEADDecrypt(void *out, size_t outLen, const void *key32, 
 - (UInt160)RMD160;
 - (UInt160)hash160;
 - (UInt128)MD5;
-- (NSData *)reverse;
+- (NSData * _Nonnull)reverse;
 
 - (uint8_t)UInt8AtOffset:(NSUInteger)offset;
 - (uint16_t)UInt16AtOffset:(NSUInteger)offset;
 - (uint32_t)UInt32AtOffset:(NSUInteger)offset;
 - (uint64_t)UInt64AtOffset:(NSUInteger)offset;
-- (uint64_t)varIntAtOffset:(NSUInteger)offset length:(NSUInteger *)length;
+- (uint64_t)varIntAtOffset:(NSUInteger)offset length:(NSUInteger * _Nonnull)length;
 - (UInt256)hashAtOffset:(NSUInteger)offset;
-- (NSString *)stringAtOffset:(NSUInteger)offset length:(NSUInteger *)length;
-- (NSData *)dataAtOffset:(NSUInteger)offset length:(NSUInteger *)length;
+- (NSString *_Nullable)stringAtOffset:(NSUInteger)offset length:(NSUInteger *_Nonnull)length;
+- (NSData *_Nonnull)dataAtOffset:(NSUInteger)offset length:(NSUInteger *_Nonnull)length;
 
-- (NSArray *)scriptElements; // an array of NSNumber and NSData objects representing each script element
+- (NSArray *_Nonnull)scriptElements; // an array of NSNumber and NSData objects representing each script element
 - (int)intValue; // returns the opcode used to store the receiver in a script (i.e. OP_PUSHDATA1)
 
-- (NSString *)base58String;
+- (NSString *_Nonnull)base58String;
 
 @end

--- a/BreadWalletTests/BRReplicatedKVStoreTests.swift
+++ b/BreadWalletTests/BRReplicatedKVStoreTests.swift
@@ -1,0 +1,67 @@
+//
+//  BRReplicatedKVStoreTests.swift
+//  BreadWallet
+//
+//  Created by Samuel Sutch on 8/10/16.
+//  Copyright © 2016 Aaron Voisine. All rights reserved.
+//
+
+import XCTest
+@testable import breadwallet
+
+class BRReplicatedKVStoreTest: XCTestCase {
+    var store: BRReplicatedKVStore!
+    
+    override func setUp() {
+        super.setUp()
+        store = try! BRReplicatedKVStore()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        try! store.rmdb()
+        store = nil
+    }
+    
+    // MARK: - local db tests
+    
+    func testSetLocalDoesntThrow() {
+        let (v1, t1) = try! store.set("hello", value: [0, 0, 0])
+        XCTAssertEqual(1, v1)
+        XCTAssertNotNil(t1)
+    }
+    
+    func testSetLocalIncrementsVersion() {
+        try! store.set("hello", value: [0, 1])
+        XCTAssertEqual(try! store.localVersion("hello"), 1)
+    }
+    
+    func testSetThenGet() {
+        let (v1, t1) = try! store.set("hello", value: [0, 1])
+        let (v, t, d, val) = try! store.get("hello")
+        XCTAssertEqual(val, [0, 1])
+        XCTAssertEqual(v1, v)
+        XCTAssertEqualWithAccuracy(t1.timeIntervalSince1970, t.timeIntervalSince1970, accuracy: 0.001)
+        XCTAssertEqual(d, false)
+    }
+    
+    func testSetThenSetIncrementsVersion() {
+        let (v1, _) = try! store.set("hello", value: [0, 1])
+        let (v2, _) = try! store.set("hello", value: [0, 2])
+        XCTAssertEqual(v2, v1 + 1)
+    }
+    
+    func testSetThenDel() {
+        let (v1, _) = try! store.set("hello", value: [0, 1])
+        let (v2, _) = try! store.del("hello")
+        XCTAssertEqual(v2, v1 + 1)
+    }
+    
+    func testSetThenDelThenGet() {
+        let (v1, _) = try! store.set("hello", value: [0, 1])
+        try! store.del("hello")
+        let (v2, _, d, _) = try! store.get("hello")
+        XCTAssert(d)
+        XCTAssertEqual(v2, v1 + 1)
+    }
+}

--- a/BreadWalletTests/BRReplicatedKVStoreTests.swift
+++ b/BreadWalletTests/BRReplicatedKVStoreTests.swift
@@ -94,7 +94,7 @@ class BRReplicatedKVStoreTest: XCTestCase {
     
     override func tearDown() {
         super.tearDown()
-        try! store.rmdb()
+        //try! store.rmdb()
         store = nil
     }
     
@@ -178,6 +178,6 @@ class BRReplicatedKVStoreTest: XCTestCase {
         }
         waitForExpectationsWithTimeout(1, handler: nil)
         let allKeys = try! store.localKeys()
-        XCTAssertEqual(adapter.db.count, allKeys.count)
+        XCTAssertEqual(adapter.db.count - 1, allKeys.count) // minus 1: there is a deleted key that needent be synced
     }
 }

--- a/BreadWalletTests/BRReplicatedKVStoreTests.swift
+++ b/BreadWalletTests/BRReplicatedKVStoreTests.swift
@@ -100,6 +100,7 @@ class BRReplicatedKVStoreTest: XCTestCase {
         super.setUp()
         adapter = BRReplicatedKVStoreTestAdapter(testCase: self)
         store = try! BRReplicatedKVStore(encryptionKey: key, remoteAdaptor: adapter)
+        store.encryptedReplication = false
     }
     
     override func tearDown() {
@@ -376,5 +377,19 @@ class BRReplicatedKVStoreTest: XCTestCase {
         }
         waitForExpectationsWithTimeout(1, handler: nil)
         XCTAssertDatabasesAreSynced()
+    }
+    
+    func testEnableEncryptedReplication() {
+        adapter.db.removeAll()
+        store.encryptedReplication = true
+        
+        try! store.set("derp", value: [0, 1], localVer: 0)
+        let exp = expectationWithDescription("sync")
+        store.syncAllKeys { (err) in
+            XCTAssertNil(err)
+            exp.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssertNotEqual(adapter.db["derp"]!.2, [0, 1])
     }
 }

--- a/BreadWalletTests/BRReplicatedKVStoreTests.swift
+++ b/BreadWalletTests/BRReplicatedKVStoreTests.swift
@@ -99,7 +99,7 @@ class BRReplicatedKVStoreTest: XCTestCase {
     
     override func tearDown() {
         super.tearDown()
-        //try! store.rmdb()
+        try! store.rmdb()
         store = nil
     }
     
@@ -186,7 +186,7 @@ class BRReplicatedKVStoreTest: XCTestCase {
         XCTAssertEqual(adapter.db.count - 1, allKeys.count) // minus 1: there is a deleted key that needent be synced
     }
     
-    func testSyncAddsLocalKeysToRemote() {
+    func XXtestSyncAddsLocalKeysToRemote() {
         store.syncImmediately = false
         try! store.set("derp", value: [0, 1], localVer: 0)
         let exp = expectationWithDescription("sync")
@@ -198,7 +198,7 @@ class BRReplicatedKVStoreTest: XCTestCase {
         XCTAssertEqual(adapter.db["derp"]!.2, [0, 1])
     }
     
-    func testSyncSavesRemoteVersion() {
+    func XXtestSyncSavesRemoteVersion() {
         let exp = expectationWithDescription("sync")
         store.syncAllKeys { err in
             XCTAssertNil(err)

--- a/BreadWalletTests/BRReplicatedKVStoreTests.swift
+++ b/BreadWalletTests/BRReplicatedKVStoreTests.swift
@@ -59,7 +59,12 @@ class BRReplicatedKVStoreTestAdapter: BRRemoteKVStoreAdaptor {
         print("[TestRemoteKVStore] PUT \(key) \(version)")
         dispatch_async(dispatch_get_main_queue()) { 
             guard let obj = self.db[key] else {
-                return completionFunc(0, NSDate(), .NotFound)
+                if version != 0 {
+                    return completionFunc(1, NSDate(), .NotFound)
+                }
+                let newObj = (UInt64(1), NSDate(), value, false)
+                self.db[key] = newObj
+                return completionFunc(1, newObj.1, nil)
             }
             if version != obj.0 {
                 return completionFunc(0, NSDate(), .Conflict)
@@ -99,8 +104,30 @@ class BRReplicatedKVStoreTest: XCTestCase {
     
     override func tearDown() {
         super.tearDown()
-        try! store.rmdb()
+//        try! store.rmdb()
         store = nil
+    }
+    
+    func XCTAssertDatabasesAreSynced() { // this only works for keys that are not marked deleted
+        var remoteKV = [String: [UInt8]]()
+        for (k, v) in adapter.db {
+            if !v.3 {
+                remoteKV[k] = v.2
+            }
+        }
+        let allLocalKeys = try! store.localKeys()
+        var localKV = [String: [UInt8]]()
+        for i in allLocalKeys {
+            if !i.4 {
+                localKV[i.0] = try! store.get(i.0).3
+            }
+        }
+        for (k, v) in remoteKV {
+            XCTAssertEqual(v, localKV[k] ?? [])
+        }
+        for (k, v) in localKV {
+            XCTAssertEqual(v, remoteKV[k] ?? [])
+        }
     }
     
     // MARK: - local db tests
@@ -173,6 +200,14 @@ class BRReplicatedKVStoreTest: XCTestCase {
         XCTAssertEqual(false, lst[0].4)
     }
     
+    func testSetRemoteVersion() {
+        let (v1, _) = try! store.set("hello", value: [0, 1], localVer: 0)
+        let (newV, _) = try! store.setRemoteVersion("hello", localVer: v1, remoteVer: 1)
+        XCTAssertEqual(newV, v1 + 1)
+        let rmv = try! store.remoteVersion("hello")
+        XCTAssertEqual(rmv, 1)
+    }
+    
     // MARK: - syncing tests
     
     func testBasicSyncGetAllObjects() {
@@ -184,9 +219,28 @@ class BRReplicatedKVStoreTest: XCTestCase {
         waitForExpectationsWithTimeout(1, handler: nil)
         let allKeys = try! store.localKeys()
         XCTAssertEqual(adapter.db.count - 1, allKeys.count) // minus 1: there is a deleted key that needent be synced
+        XCTAssertDatabasesAreSynced()
     }
     
-    func XXtestSyncAddsLocalKeysToRemote() {
+    func testSyncTenTimes() {
+        let exp = expectationWithDescription("sync")
+        var n = 10
+        var handler: (e: ErrorType?) -> () = { e in return }
+        handler = { (e: ErrorType?) in
+            XCTAssertNil(e)
+            if n > 0 {
+                self.store.syncAllKeys(handler)
+                n -= 1
+            } else {
+                exp.fulfill()
+            }
+        }
+        handler(e: nil)
+        waitForExpectationsWithTimeout(2, handler: nil)
+        XCTAssertDatabasesAreSynced()
+    }
+    
+    func testSyncAddsLocalKeysToRemote() {
         store.syncImmediately = false
         try! store.set("derp", value: [0, 1], localVer: 0)
         let exp = expectationWithDescription("sync")
@@ -196,9 +250,10 @@ class BRReplicatedKVStoreTest: XCTestCase {
         }
         waitForExpectationsWithTimeout(1, handler: nil)
         XCTAssertEqual(adapter.db["derp"]!.2, [0, 1])
+        XCTAssertDatabasesAreSynced()
     }
     
-    func XXtestSyncSavesRemoteVersion() {
+    func testSyncSavesRemoteVersion() {
         let exp = expectationWithDescription("sync")
         store.syncAllKeys { err in
             XCTAssertNil(err)
@@ -208,21 +263,118 @@ class BRReplicatedKVStoreTest: XCTestCase {
         let rv = try! store.remoteVersion("hello")
         XCTAssertEqual(adapter.db["hello"]!.0, 1) // it should not have done any mutations
         XCTAssertEqual(adapter.db["hello"]!.0, rv) // only saved the remote version
+        XCTAssertDatabasesAreSynced()
+    }
+    
+    func testSyncPreventsAnotherConcurrentSync() {
+        let exp1 = expectationWithDescription("sync")
+        let exp2 = expectationWithDescription("sync2")
+        store.syncAllKeys { e in exp1.fulfill() }
+        store.syncAllKeys { (e) in
+            XCTAssertEqual(e, BRReplicatedKVStoreError.AlreadyReplicating)
+            exp2.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
     }
     
     func testLocalDeleteReplicates() {
-        
+        let exp1 = expectationWithDescription("sync1")
+        store.syncImmediately = false
+        try! store.set("goodbye_cruel_world", value: [0, 1], localVer: 0)
+        store.syncAllKeys { (e) in
+            XCTAssertNil(e)
+            exp1.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssertDatabasesAreSynced()
+        try! store.del("goodbye_cruel_world",
+                       localVer: try! store.localVersion("goodbye_cruel_world").0)
+        let exp2 = expectationWithDescription("sync2")
+        store.syncAllKeys { (e) in
+            XCTAssertNil(e)
+            exp2.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssertDatabasesAreSynced()
+        XCTAssertEqual(adapter.db["goodbye_cruel_world"]!.3, true)
     }
     
     func testLocalUpdateReplicates() {
-        
+        let exp1 = expectationWithDescription("sync1")
+        store.syncImmediately = false
+        try! store.set("goodbye_cruel_world", value: [0, 1], localVer: 0)
+        store.syncAllKeys { (e) in
+            XCTAssertNil(e)
+            exp1.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssertDatabasesAreSynced()
+        try! store.set("goodbye_cruel_world", value: [1, 0, 0, 1],
+                       localVer: try! store.localVersion("goodbye_cruel_world").0)
+        let exp2 = expectationWithDescription("sync2")
+        store.syncAllKeys { (e) in
+            XCTAssertNil(e)
+            exp2.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssertDatabasesAreSynced()
     }
     
     func testRemoteDeleteReplicates() {
-        
+        let exp1 = expectationWithDescription("sync1")
+        store.syncAllKeys { (e) in
+            XCTAssertNil(e)
+            exp1.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssertDatabasesAreSynced()
+        adapter.db["hello"]?.0 += 1
+        adapter.db["hello"]?.1 = NSDate()
+        adapter.db["hello"]?.3 = true
+        let exp2 = expectationWithDescription("sync2")
+        store.syncAllKeys { (e) in
+            XCTAssertNil(e)
+            exp2.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssertDatabasesAreSynced()
+        let h = try! store.get("hello")
+        XCTAssertEqual(h.2, true)
+        let exp3 = expectationWithDescription("sync3")
+        store.syncAllKeys { (e) in
+            XCTAssertNil(e)
+            exp3.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssertDatabasesAreSynced()
     }
     
     func testRemoteUpdateReplicates() {
-        
+        let exp1 = expectationWithDescription("sync1")
+        store.syncAllKeys { (e) in
+            XCTAssertNil(e)
+            exp1.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssertDatabasesAreSynced()
+        adapter.db["hello"]?.0 += 1
+        adapter.db["hello"]?.1 = NSDate()
+        adapter.db["hello"]?.2 = [0, 1, 1, 1, 1, 1, 11 , 1, 1, 1, 1, 1, 0x8c]
+        let exp2 = expectationWithDescription("sync2")
+        store.syncAllKeys { (e) in
+            XCTAssertNil(e)
+            exp2.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssertDatabasesAreSynced()
+        let h = try! store.get("hello")
+        XCTAssertEqual(h.3, [0, 1, 1, 1, 1, 1, 11 , 1, 1, 1, 1, 1, 0x8c])
+        let exp3 = expectationWithDescription("sync3")
+        store.syncAllKeys { (e) in
+            XCTAssertNil(e)
+            exp3.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssertDatabasesAreSynced()
     }
 }

--- a/BreadWalletTests/BRReplicatedKVStoreTests.swift
+++ b/BreadWalletTests/BRReplicatedKVStoreTests.swift
@@ -9,13 +9,87 @@
 import XCTest
 @testable import breadwallet
 
+class BRReplicatedKVStoreTestAdapter: BRRemoteKVStoreAdaptor {
+    let testCase: XCTestCase
+    var db = [String: (UInt64, NSDate, [UInt8], Bool)]()
+    
+    init(testCase: XCTestCase) {
+        self.testCase = testCase
+        db["hello"] = (1, NSDate(), [0, 1], false)
+        db["removed"] = (2, NSDate(), [0, 2], true)
+        for i in 1...20 {
+            db["testkey-\(i)"] = (1, NSDate(), [0, UInt8(i + 2)], false)
+        }
+    }
+    
+    func keys(completionFunc: ([(String, UInt64, NSDate, BRRemoteKVStoreError?)], BRRemoteKVStoreError?) -> ()) {
+        dispatch_async(dispatch_get_main_queue()) { 
+            let res = self.db.map { (t) -> (String, UInt64, NSDate, BRRemoteKVStoreError?) in
+                return (t.0, t.1.0, t.1.1, t.1.3 ? BRRemoteKVStoreError.Tombstone : nil)
+            }
+            completionFunc(res, nil)
+        }
+    }
+    
+    func ver(key: String, completionFunc: (UInt64, NSDate, BRRemoteKVStoreError?) -> ()) {
+        dispatch_async(dispatch_get_main_queue()) { 
+            guard let obj = self.db[key] else {
+                return completionFunc(0, NSDate(), .NotFound)
+            }
+            completionFunc(obj.0, obj.1, obj.3 ? .Tombstone : nil)
+        }
+    }
+    
+    func get(key: String, version: UInt64, completionFunc: (UInt64, NSDate, [UInt8], BRRemoteKVStoreError?) -> ()) {
+        dispatch_async(dispatch_get_main_queue()) { 
+            guard let obj = self.db[key] else {
+                return completionFunc(0, NSDate(), [], .NotFound)
+            }
+            if version != obj.0 {
+                return completionFunc(0, NSDate(), [], .Conflict)
+            }
+            completionFunc(obj.0, obj.1, obj.2, obj.3 ? .Tombstone : nil)
+        }
+    }
+    
+    func put(key: String, value: [UInt8], version: UInt64, completionFunc: (UInt64, NSDate, BRRemoteKVStoreError?) -> ()) {
+        dispatch_async(dispatch_get_main_queue()) { 
+            guard let obj = self.db[key] else {
+                return completionFunc(0, NSDate(), .NotFound)
+            }
+            if version != obj.0 {
+                return completionFunc(0, NSDate(), .Conflict)
+            }
+            let newObj = (obj.0 + 1, NSDate(), value, false)
+            self.db[key] = newObj
+            completionFunc(newObj.0, newObj.1, nil)
+        }
+    }
+    
+    func del(key: String, version: UInt64, completionFunc: (UInt64, NSDate, BRRemoteKVStoreError?) -> ()) {
+        dispatch_async(dispatch_get_main_queue()) { 
+            guard let obj = self.db[key] else {
+                return completionFunc(0, NSDate(), .NotFound)
+            }
+            if version != obj.0 {
+                return completionFunc(0, NSDate(), .Conflict)
+            }
+            let newObj = (obj.0 + 1, NSDate(), obj.2, true)
+            self.db[key] = newObj
+            completionFunc(newObj.0, newObj.1, nil)
+        }
+    }
+}
+
 class BRReplicatedKVStoreTest: XCTestCase {
     var store: BRReplicatedKVStore!
     var key = BRKey(privateKey: "S6c56bnXQiBjk9mqSYE7ykVQ7NzrRy")!
+    var adapter: BRReplicatedKVStoreTestAdapter!
     
     override func setUp() {
         super.setUp()
-        store = try! BRReplicatedKVStore(encryptionKey: key)
+        adapter = BRReplicatedKVStoreTestAdapter(testCase: self)
+        store = try! BRReplicatedKVStore(encryptionKey: key, remoteAdaptor: adapter)
     }
     
     override func tearDown() {
@@ -27,18 +101,18 @@ class BRReplicatedKVStoreTest: XCTestCase {
     // MARK: - local db tests
     
     func testSetLocalDoesntThrow() {
-        let (v1, t1) = try! store.set("hello", value: [0, 0, 0])
+        let (v1, t1) = try! store.set("hello", value: [0, 0, 0], localVer: 0)
         XCTAssertEqual(1, v1)
         XCTAssertNotNil(t1)
     }
     
     func testSetLocalIncrementsVersion() {
-        try! store.set("hello", value: [0, 1])
-        XCTAssertEqual(try! store.localVersion("hello"), 1)
+        try! store.set("hello", value: [0, 1], localVer: 0)
+        XCTAssertEqual(try! store.localVersion("hello").0, 1)
     }
     
     func testSetThenGet() {
-        let (v1, t1) = try! store.set("hello", value: [0, 1])
+        let (v1, t1) = try! store.set("hello", value: [0, 1], localVer: 0)
         let (v, t, d, val) = try! store.get("hello")
         XCTAssertEqual(val, [0, 1])
         XCTAssertEqual(v1, v)
@@ -47,22 +121,63 @@ class BRReplicatedKVStoreTest: XCTestCase {
     }
     
     func testSetThenSetIncrementsVersion() {
-        let (v1, _) = try! store.set("hello", value: [0, 1])
-        let (v2, _) = try! store.set("hello", value: [0, 2])
+        let (v1, _) = try! store.set("hello", value: [0, 1], localVer: 0)
+        let (v2, _) = try! store.set("hello", value: [0, 2], localVer: v1)
         XCTAssertEqual(v2, v1 + 1)
     }
     
     func testSetThenDel() {
-        let (v1, _) = try! store.set("hello", value: [0, 1])
-        let (v2, _) = try! store.del("hello")
+        let (v1, _) = try! store.set("hello", value: [0, 1], localVer: 0)
+        let (v2, _) = try! store.del("hello", localVer: v1)
         XCTAssertEqual(v2, v1 + 1)
     }
     
     func testSetThenDelThenGet() {
-        let (v1, _) = try! store.set("hello", value: [0, 1])
-        try! store.del("hello")
+        let (v1, _) = try! store.set("hello", value: [0, 1], localVer: 0)
+        try! store.del("hello", localVer: v1)
         let (v2, _, d, _) = try! store.get("hello")
         XCTAssert(d)
         XCTAssertEqual(v2, v1 + 1)
+    }
+    
+    func testSetWithIncorrectFirstVersionFails() {
+        XCTAssertThrowsError(try store.set("hello", value: [0, 1], localVer: 1))
+    }
+    
+    func testSetWithStaleVersionFails() {
+        try! store.set("hello", value: [0, 1], localVer: 0)
+        XCTAssertThrowsError(try store.set("hello", value: [0, 1], localVer: 0))
+    }
+    
+    func testGetNonExistentKeyFails() {
+        XCTAssertThrowsError(try store.get("hello"))
+    }
+    
+    func testGetNonExistentKeyVersionFails() {
+        XCTAssertThrowsError(try store.get("hello", version: 1))
+    }
+    
+    func testGetAllKeys() {
+        let (v1, t1) = try! store.set("hello", value: [0, 1], localVer: 0)
+        let lst = try! store.localKeys()
+        XCTAssertEqual(1, lst.count)
+        XCTAssertEqual("hello", lst[0].0)
+        XCTAssertEqual(v1, lst[0].1)
+        XCTAssertEqualWithAccuracy(t1.timeIntervalSince1970, lst[0].2.timeIntervalSince1970, accuracy: 0.001)
+        XCTAssertEqual(0, lst[0].3)
+        XCTAssertEqual(false, lst[0].4)
+    }
+    
+    // MARK: - syncing tests
+    
+    func testBasicSyncGetAllObjects() {
+        let exp = expectationWithDescription("sync")
+        store.syncAllKeys { (err) in
+            XCTAssertNil(err)
+            exp.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+        let allKeys = try! store.localKeys()
+        XCTAssertEqual(adapter.db.count, allKeys.count)
     }
 }

--- a/BreadWalletTests/BRReplicatedKVStoreTests.swift
+++ b/BreadWalletTests/BRReplicatedKVStoreTests.swift
@@ -104,7 +104,7 @@ class BRReplicatedKVStoreTest: XCTestCase {
     
     override func tearDown() {
         super.tearDown()
-//        try! store.rmdb()
+        try! store.rmdb()
         store = nil
     }
     

--- a/BreadWalletTests/BRReplicatedKVStoreTests.swift
+++ b/BreadWalletTests/BRReplicatedKVStoreTests.swift
@@ -338,8 +338,8 @@ class BRReplicatedKVStoreTest: XCTestCase {
         }
         waitForExpectationsWithTimeout(1, handler: nil)
         XCTAssertDatabasesAreSynced()
-        let h = try! store.get("hello")
-        XCTAssertEqual(h.2, true)
+        let (_, _, h, _) = try! store.get("hello")
+        XCTAssertEqual(h, true)
         let exp3 = expectationWithDescription("sync3")
         store.syncAllKeys { (e) in
             XCTAssertNil(e)
@@ -367,8 +367,8 @@ class BRReplicatedKVStoreTest: XCTestCase {
         }
         waitForExpectationsWithTimeout(1, handler: nil)
         XCTAssertDatabasesAreSynced()
-        let h = try! store.get("hello")
-        XCTAssertEqual(h.3, [0, 1, 1, 1, 1, 1, 11 , 1, 1, 1, 1, 1, 0x8c])
+        let (_, _, _, b) = try! store.get("hello")
+        XCTAssertEqual(b, [0, 1, 1, 1, 1, 1, 11 , 1, 1, 1, 1, 1, 0x8c])
         let exp3 = expectationWithDescription("sync3")
         store.syncAllKeys { (e) in
             XCTAssertNil(e)

--- a/BreadWalletTests/BRReplicatedKVStoreTests.swift
+++ b/BreadWalletTests/BRReplicatedKVStoreTests.swift
@@ -11,10 +11,11 @@ import XCTest
 
 class BRReplicatedKVStoreTest: XCTestCase {
     var store: BRReplicatedKVStore!
+    var key = BRKey(privateKey: "S6c56bnXQiBjk9mqSYE7ykVQ7NzrRy")!
     
     override func setUp() {
         super.setUp()
-        store = try! BRReplicatedKVStore()
+        store = try! BRReplicatedKVStore(encryptionKey: key)
     }
     
     override func tearDown() {


### PR DESCRIPTION
#### Synopsis

This PR adds the KV Store, a replicated, encrypted, general purpose key-value storage solution to the iOS client.

Swift:

```swift
let kv = BRReplicatedKVStore(key: k, adaptor: client.adaptor)
// create a new key
try kv.set("hello", localVer: 0)
// get a key
let (version, modified, deleted, bytes) = try kv.get("hello")
// sync all keys
kv.syncAllKeys { e in
    print("Done syncing, if there was an error, here it is: \(e)")
}
```

Objective-C:

```objc
BRReplicatedKVStore *kv = client.kv;

NSError *kvErr = nil;
BRKVStoreObject *obj = [[BRKVStoreObject alloc] initWithKey:@"hello" version:0 lastModified:[NSDate date]
                                                    deleted:false data:[NSData data]];
}
[kv set:obj error:&kvErr];
if (kvErr != nil) {
    NSLog(@"Error setting kv object err=%@", kvErr);
}

BRKVStoreObject *objectAgain = [kv get:@"hello" error:&kvErr];

[kv sync:^(NSError * err) {
    NSLog(@"Finished syncing: error=%@", err);
}];
```

#### Local database

Objects in the local database are a 4-tuple of (Key, Version, LastModifiedDate, Bytes) where the primary key is the tuple (Key, Version). The objects are protected by optimistic locking using the Version, so concurrent reads and writes are possible, with the possibility to resolve conflicts should a version number not match.

#### Remote storage/backup

The remote API operates in much the same way. All methods are authenticated and every user has a private keyspace. Each of the GET/PUT/DEL API endpoints is protected by a version number provided by the client in the `If-None-Match` header. If the version number provided the by the client doesn't match the version number on the server, the request is rejected. Every API endpoint will return both the Version and the LastModifiedDate of its data in the `ETag` and `Last-Modified` headers, respectively. Here is a rough rundown of the remote API methods. 

- `HEAD /kv/1/:key` - retrieve the most recent version and last modified date for a given key
- `GET /kv/1/:key` - get the value of the requested key and version, pass ETag as 0 to get the most recent version
- `PUT /kv/1/:key` - create a new version of this key and save its data
- `DELETE /kv/1/:key` - mark a key as deleted
- `GET /kv/_all_keys` - return a list of all of the users keys

Possible response codes are:

- `200` - successful request
- `204` - successful request, with no response body
- `400` - bad request: invalid request, possibly invalid key
- `401` - not authorized: missing authentication
- `404` - not found: key or key/version requested does not exist
- `409` - conflict: provided version does not match the on record version
- `410` - gone: the requested key or key/version has been marked as removed
- `500` - internal error: something went wrong that the client can't correct

Because the keys are used in the URLs, they must by URL-safe, and must not start with an underscore (\_) as those may be used for future extension endpoints.

#### Replication

The syncAllKeys (or sync, in Objective-C) method will perform a bi-directional replication between the client and the remote API. Each key is updated using a last-write-wins strategy and uses a time accuracy of 1 millisecond to determine the newest object. However, since the clocks of client and server will likely be skewed from one another, the practical accuracy of the time comparison is much lower. Therefore, the key-value-store should not be used for highly sensitive data where absolute consistency is a must, or for keys that might be changing more than once-per-second with frequent replications between multiple clients.

#### Encryption

The values of objects in the store are encrypted using the user's authentication private key, using ChaCha20-Poly1305 in AEAD mode. By using the bitauth authentication key (derrivation path m/1H/0), the user will be able to decrypt the data as long as they have their recovery phrase. Data is encrypted on the device in rest and only encrypted values are ever replicated to the server.