### PR TITLE
Transaction Metadata Object

### DIFF
--- a/BreadWallet.xcodeproj/project.pbxproj
+++ b/BreadWallet.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		222040C81C1A3803005CE1C3 /* BRHTTPServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222040C71C1A3803005CE1C3 /* BRHTTPServerTests.swift */; };
 		222E7F561C46E9B8009AB45D /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 222E7F551C46E9B8009AB45D /* Security.framework */; };
 		222E7F581C46E9BE009AB45D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 222E7F571C46E9BE009AB45D /* SystemConfiguration.framework */; };
+		22331F441D60312F00F29551 /* BRKVStoreObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22331F431D60312F00F29551 /* BRKVStoreObjects.swift */; };
 		225383011C694D7400968BEE /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 225383001C694D7400968BEE /* CoreLocation.framework */; };
 		2284B63F1C7BD28F0012ECDF /* BRAWKeypad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F45A0A1C30EAB700B07A15 /* BRAWKeypad.swift */; };
 		229279981C695C4200C98E78 /* BRHTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229279971C695C4200C98E78 /* BRHTTPServer.swift */; };
@@ -227,6 +228,7 @@
 		222040C71C1A3803005CE1C3 /* BRHTTPServerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRHTTPServerTests.swift; sourceTree = "<group>"; };
 		222E7F551C46E9B8009AB45D /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		222E7F571C46E9BE009AB45D /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		22331F431D60312F00F29551 /* BRKVStoreObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRKVStoreObjects.swift; sourceTree = "<group>"; };
 		225383001C694D7400968BEE /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		229279971C695C4200C98E78 /* BRHTTPServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRHTTPServer.swift; sourceTree = "<group>"; };
 		229279991C695CAE00C98E78 /* BRHTTPFileMiddleware.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRHTTPFileMiddleware.swift; sourceTree = "<group>"; };
@@ -682,6 +684,7 @@
 				752E28A919234AE300DB5A3C /* BRTxOutputEntity.m */,
 				75F2E0D41BEAA6A400EAE861 /* BRTxMetadataEntity.h */,
 				75F2E0D51BEAA6A400EAE861 /* BRTxMetadataEntity.m */,
+				22331F431D60312F00F29551 /* BRKVStoreObjects.swift */,
 			);
 			name = Entities;
 			sourceTree = "<group>";
@@ -1327,6 +1330,7 @@
 				220128D91C77B3100001CAC1 /* BRHTTPIndexMiddleware.swift in Sources */,
 				752E28DB19234C3600DB5A3C /* BRWalletManager.m in Sources */,
 				752E28D319234C3600DB5A3C /* BRMerkleBlock.m in Sources */,
+				22331F441D60312F00F29551 /* BRKVStoreObjects.swift in Sources */,
 				222040C41C1A0903005CE1C3 /* BRWebViewController.swift in Sources */,
 				752E28D019234C3600DB5A3C /* BRBloomFilter.m in Sources */,
 				752E28D619234C3600DB5A3C /* BRPeer.m in Sources */,

--- a/BreadWallet.xcodeproj/project.pbxproj
+++ b/BreadWallet.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 		222E7F561C46E9B8009AB45D /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 222E7F551C46E9B8009AB45D /* Security.framework */; };
 		222E7F581C46E9BE009AB45D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 222E7F571C46E9BE009AB45D /* SystemConfiguration.framework */; };
 		2230E23D1D60FA52001EF2E9 /* NSDataExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2230E23C1D60FA52001EF2E9 /* NSDataExtensionTests.swift */; };
+		2230E23F1D6109AD001EF2E9 /* BRKVStoreObjectsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2230E23E1D6109AD001EF2E9 /* BRKVStoreObjectsTests.swift */; };
+		2230E2411D610A63001EF2E9 /* BRCoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2230E2401D610A63001EF2E9 /* BRCoding.swift */; };
+		2230E2431D610C91001EF2E9 /* BRCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2230E2421D610C91001EF2E9 /* BRCodingTests.swift */; };
+		2230E2441D610D9A001EF2E9 /* BRCoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2230E2401D610A63001EF2E9 /* BRCoding.swift */; };
 		22331F441D60312F00F29551 /* BRKVStoreObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22331F431D60312F00F29551 /* BRKVStoreObjects.swift */; };
 		225383011C694D7400968BEE /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 225383001C694D7400968BEE /* CoreLocation.framework */; };
 		2284B63F1C7BD28F0012ECDF /* BRAWKeypad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F45A0A1C30EAB700B07A15 /* BRAWKeypad.swift */; };
@@ -230,6 +234,9 @@
 		222E7F551C46E9B8009AB45D /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		222E7F571C46E9BE009AB45D /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		2230E23C1D60FA52001EF2E9 /* NSDataExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDataExtensionTests.swift; sourceTree = "<group>"; };
+		2230E23E1D6109AD001EF2E9 /* BRKVStoreObjectsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRKVStoreObjectsTests.swift; sourceTree = "<group>"; };
+		2230E2401D610A63001EF2E9 /* BRCoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRCoding.swift; sourceTree = "<group>"; };
+		2230E2421D610C91001EF2E9 /* BRCodingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRCodingTests.swift; sourceTree = "<group>"; };
 		22331F431D60312F00F29551 /* BRKVStoreObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRKVStoreObjects.swift; sourceTree = "<group>"; };
 		225383001C694D7400968BEE /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		229279971C695C4200C98E78 /* BRHTTPServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRHTTPServer.swift; sourceTree = "<group>"; };
@@ -579,6 +586,7 @@
 				2292799E1C695D2800C98E78 /* BRTar.swift */,
 				229279A01C695D7900C98E78 /* BRBSPatch.swift */,
 				22BF17461CDF831800AA41C6 /* Extensions.swift */,
+				2230E2401D610A63001EF2E9 /* BRCoding.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -907,6 +915,8 @@
 				222040C71C1A3803005CE1C3 /* BRHTTPServerTests.swift */,
 				2299CF381D5C32B70055EA28 /* BRReplicatedKVStoreTests.swift */,
 				2230E23C1D60FA52001EF2E9 /* NSDataExtensionTests.swift */,
+				2230E2421D610C91001EF2E9 /* BRCodingTests.swift */,
+				2230E23E1D6109AD001EF2E9 /* BRKVStoreObjectsTests.swift */,
 				75CE50B51B5216F100DBC18C /* Info.plist */,
 				75EDC0E71CD92EA90090B838 /* BreadWalletTests-Bridging-Header.h */,
 			);
@@ -1298,6 +1308,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2230E2441D610D9A001EF2E9 /* BRCoding.swift in Sources */,
 				22F04A001C9714EF00F137D8 /* BRUserDefaultsSwitchCell.m in Sources */,
 				752E28AA19234AE300DB5A3C /* BRAddressEntity.m in Sources */,
 				75AA5F55194143D5003F23BD /* BRBouncyBurgerButton.m in Sources */,
@@ -1377,10 +1388,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				2230E23D1D60FA52001EF2E9 /* NSDataExtensionTests.swift in Sources */,
+				2230E2431D610C91001EF2E9 /* BRCodingTests.swift in Sources */,
 				22DE8CF31D02407F007F07F3 /* BRWalletConstants.m in Sources */,
 				2299CF391D5C32B70055EA28 /* BRReplicatedKVStoreTests.swift in Sources */,
 				222040C81C1A3803005CE1C3 /* BRHTTPServerTests.swift in Sources */,
+				2230E2411D610A63001EF2E9 /* BRCoding.swift in Sources */,
 				75D5F3F3191EC270004AB296 /* BreadWalletTests.m in Sources */,
+				2230E23F1D6109AD001EF2E9 /* BRKVStoreObjectsTests.swift in Sources */,
 				22FCD22C1C0E68C80066D798 /* BRTarTests.swift in Sources */,
 				22B6A44A1C0ECB7800673913 /* BRBSPatchTests.swift in Sources */,
 			);

--- a/BreadWallet.xcodeproj/project.pbxproj
+++ b/BreadWallet.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		222040C81C1A3803005CE1C3 /* BRHTTPServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222040C71C1A3803005CE1C3 /* BRHTTPServerTests.swift */; };
 		222E7F561C46E9B8009AB45D /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 222E7F551C46E9B8009AB45D /* Security.framework */; };
 		222E7F581C46E9BE009AB45D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 222E7F571C46E9BE009AB45D /* SystemConfiguration.framework */; };
+		2230E23D1D60FA52001EF2E9 /* NSDataExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2230E23C1D60FA52001EF2E9 /* NSDataExtensionTests.swift */; };
 		22331F441D60312F00F29551 /* BRKVStoreObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22331F431D60312F00F29551 /* BRKVStoreObjects.swift */; };
 		225383011C694D7400968BEE /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 225383001C694D7400968BEE /* CoreLocation.framework */; };
 		2284B63F1C7BD28F0012ECDF /* BRAWKeypad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F45A0A1C30EAB700B07A15 /* BRAWKeypad.swift */; };
@@ -228,6 +229,7 @@
 		222040C71C1A3803005CE1C3 /* BRHTTPServerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRHTTPServerTests.swift; sourceTree = "<group>"; };
 		222E7F551C46E9B8009AB45D /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		222E7F571C46E9BE009AB45D /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		2230E23C1D60FA52001EF2E9 /* NSDataExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDataExtensionTests.swift; sourceTree = "<group>"; };
 		22331F431D60312F00F29551 /* BRKVStoreObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRKVStoreObjects.swift; sourceTree = "<group>"; };
 		225383001C694D7400968BEE /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		229279971C695C4200C98E78 /* BRHTTPServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BRHTTPServer.swift; sourceTree = "<group>"; };
@@ -904,6 +906,7 @@
 				22B6A4491C0ECB7800673913 /* BRBSPatchTests.swift */,
 				222040C71C1A3803005CE1C3 /* BRHTTPServerTests.swift */,
 				2299CF381D5C32B70055EA28 /* BRReplicatedKVStoreTests.swift */,
+				2230E23C1D60FA52001EF2E9 /* NSDataExtensionTests.swift */,
 				75CE50B51B5216F100DBC18C /* Info.plist */,
 				75EDC0E71CD92EA90090B838 /* BreadWalletTests-Bridging-Header.h */,
 			);
@@ -1373,6 +1376,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2230E23D1D60FA52001EF2E9 /* NSDataExtensionTests.swift in Sources */,
 				22DE8CF31D02407F007F07F3 /* BRWalletConstants.m in Sources */,
 				2299CF391D5C32B70055EA28 /* BRReplicatedKVStoreTests.swift in Sources */,
 				222040C81C1A3803005CE1C3 /* BRHTTPServerTests.swift in Sources */,

--- a/BreadWallet/BRAPIClient.swift
+++ b/BreadWallet/BRAPIClient.swift
@@ -768,23 +768,3 @@ func buildRequestSigningString(r: NSMutableURLRequest) -> String {
     }
 }
 
-extension NSData {
-    var hexString : String {
-        let buf = UnsafePointer<UInt8>(bytes)
-        let charA = UInt8(UnicodeScalar("a").value)
-        let char0 = UInt8(UnicodeScalar("0").value)
-        
-        func itoh(i: UInt8) -> UInt8 {
-            return (i > 9) ? (charA + i - 10) : (char0 + i)
-        }
-        
-        let p = UnsafeMutablePointer<UInt8>.alloc(length * 2)
-        
-        for i in 0..<length {
-            p[i*2] = itoh((buf[i] >> 4) & 0xF)
-            p[i*2+1] = itoh(buf[i] & 0xF)
-        }
-        
-        return NSString(bytesNoCopy: p, length: length*2, encoding: NSUTF8StringEncoding, freeWhenDone: true) as! String
-    }
-}

--- a/BreadWallet/BRCoding.swift
+++ b/BreadWallet/BRCoding.swift
@@ -49,12 +49,12 @@ protocol BRCoding {
 
 // A basic analogue of NSKeyedArchiver, except it uses JSON and uses
 public class BRKeyedArchiver {
-    static func archivedDataWithRootObject(obj: BRCoding) -> NSData {
+    static func archivedDataWithRootObject(obj: BRCoding, compressed: Bool = true) -> NSData {
         let coder = BRCoder(data: [String : AnyObject]())
         obj.encode(coder)
         do {
             let j = try NSJSONSerialization.dataWithJSONObject(coder.data, options: [])
-            guard let bz = j.bzCompressedData else {
+            guard let bz = (compressed ? j.bzCompressedData : j) else {
                 print("compression error")
                 return NSData()
             }
@@ -68,9 +68,9 @@ public class BRKeyedArchiver {
 
 // A basic analogue of NSKeyedUnarchiver
 public class BRKeyedUnarchiver {
-    static func unarchiveObjectWithData<T: BRCoding>(data: NSData) -> T? {
+    static func unarchiveObjectWithData<T: BRCoding>(data: NSData, compressed: Bool = true) -> T? {
         do {
-            guard let bz = NSData(bzCompressedData: data),
+            guard let bz = (compressed ? NSData(bzCompressedData: data) : data),
                 j = try NSJSONSerialization.JSONObjectWithData(bz, options: []) as? [String: AnyObject] else {
                 print("BRKeyedUnarchiver invalid json object, or invalid bz data")
                 return nil

--- a/BreadWallet/BRCoding.swift
+++ b/BreadWallet/BRCoding.swift
@@ -1,0 +1,133 @@
+//
+//  BRCoding.swift
+//  BreadWallet
+//
+//  Created by Samuel Sutch on 8/14/16.
+//  Copyright © 2016 Aaron Voisine. All rights reserved.
+//
+
+import Foundation
+
+// BRCoder/BRCoding works a lot like NSCoder/NSCoding but simpler
+// instead of using optionals everywhere we just use zero values, and take advantage
+// of the swift type system somewhat to make the whole api a little cleaner
+protocol BREncodable {
+    // return anything that is JSON-able
+    func encode() -> AnyObject
+    // zeroValue is a zero-value initializer
+    static func zeroValue() -> Self
+    // decode can be passed any value which is json-able
+    static func decode(value: AnyObject) -> Self
+}
+
+extension NSDate: BREncodable {
+    func encode() -> AnyObject {
+        return self.timeIntervalSinceReferenceDate
+    }
+    
+    public class func zeroValue() -> Self {
+        return dateFromTimeIntervalSinceReferenceDate(0)
+    }
+    
+    public class func decode(value: AnyObject) -> Self {
+        let d = (value as? Double) ?? Double()
+        return dateFromTimeIntervalSinceReferenceDate(d)
+    }
+    
+    class func dateFromTimeIntervalSinceReferenceDate<T>(d: Double) -> T {
+        return NSDate(timeIntervalSinceReferenceDate: d) as! T
+    }
+}
+
+extension Int: BREncodable {
+    func encode() -> AnyObject {
+        return self
+    }
+    
+    static func zeroValue() -> Int {
+        return 0
+    }
+    
+    static func decode(s: AnyObject) -> Int {
+        return (s as? Int) ?? self.zeroValue()
+    }
+}
+
+extension String: BREncodable {
+    func encode() -> AnyObject {
+        return self
+    }
+    
+    static func zeroValue() -> String {
+        return ""
+    }
+    
+    static func decode(s: AnyObject) -> String {
+        return (s as? String) ?? self.zeroValue()
+    }
+}
+
+
+// An object which can encode and decode values
+class BRCoder {
+    var data: [String: AnyObject]
+    
+    init(data: [String: AnyObject]) {
+        self.data = data
+    }
+    
+    func encode(obj: BREncodable, key: String) {
+        self.data[key] = obj.encode()
+    }
+    
+    func decode<T: BREncodable>(key: String) -> T {
+        guard let d = self.data[key] else {
+            return T.zeroValue()
+        }
+        return T.decode(d)
+    }
+}
+
+// An object which may be encoded/decoded using the archiving/unarchiving classes below
+protocol BRCoding {
+    init?(coder decoder: BRCoder)
+    func encode(coder: BRCoder)
+}
+
+// A basic analogue of NSKeyedArchiver, except it uses JSON and uses
+class BRKeyedArchiver {
+    static func archivedDataWithRootObject(obj: BRCoding) -> NSData {
+        let coder = BRCoder(data: [String : AnyObject]())
+        obj.encode(coder)
+        do {
+            let j = try NSJSONSerialization.dataWithJSONObject(coder.data, options: [])
+            guard let bz = j.bzCompressedData else {
+                print("compression error")
+                return NSData()
+            }
+            return bz
+        } catch let e {
+            print("BRKeyedArchiver unable to archive object: \(e)")
+            return "{}".dataUsingEncoding(NSUTF8StringEncoding)!
+        }
+    }
+}
+
+// A basic analogue of NSKeyedUnarchiver
+class BRKeyedUnarchiver {
+    static func unarchiveObjectWithData<T: BRCoding>(data: NSData) -> T? {
+        do {
+            guard let bz = NSData(bzCompressedData: data),
+                j = try NSJSONSerialization.JSONObjectWithData(bz, options: []) as? [String: AnyObject] else {
+                print("BRKeyedUnarchiver invalid json object, or invalid bz data")
+                return nil
+            }
+            let coder = BRCoder(data: j)
+            return T(coder: coder)
+        } catch let e {
+            print("BRKeyedUnarchiver unable to deserialize JSON: \(e)")
+            return nil
+        }
+        
+    }
+}

--- a/BreadWallet/BRKVStoreObjects.swift
+++ b/BreadWallet/BRKVStoreObjects.swift
@@ -1,0 +1,145 @@
+//
+//  BRKVStoreObjects.swift
+//  BreadWallet
+//
+//  Created by Samuel Sutch on 8/13/16.
+//  Copyright © 2016 breadwallet LLC. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+// MARK: - Txn Metadata
+
+// Txn metadata stores additional information about a given transaction
+
+@objc class _TXMetadata: NSObject, NSCoding {
+    var classVersion: Int = 1
+    
+    var blockHeight: Int = 0
+    var exchangeRate: Int = 0
+    var exchangeRateCurrency: String = ""
+    var confirmations: Int = 0
+    var size: Int = 0
+    var firstConfirmation: NSDate = NSDate(timeIntervalSince1970: 0)
+    
+    override init() {
+        super.init()
+    }
+    
+    required init?(coder decoder: NSCoder) {
+        guard let cv = decoder.decodeObjectForKey("classVersion") as? Int else {
+            print("Unable to unarchive _TXMetadata: no version")
+            return nil
+        }
+        classVersion = cv
+        if cv >= 1 {
+            guard let bh = decoder.decodeObjectForKey("blockHeight") as? Int,
+                er = decoder.decodeObjectForKey("exchangeRate") as? Int,
+                erc = decoder.decodeObjectForKey("exchangeRateCurrency") as? String,
+                conf = decoder.decodeObjectForKey("confirmations") as? Int,
+                s = decoder.decodeObjectForKey("size") as? Int,
+                fc = decoder.decodeObjectForKey("firstConfirmation") as? NSDate else {
+                    return nil
+            }
+            blockHeight = bh
+            exchangeRate = er
+            exchangeRateCurrency = erc
+            confirmations = conf
+            size = s
+            firstConfirmation = fc
+        }
+    }
+    
+    func encodeWithCoder(coder: NSCoder) {
+        coder.encodeObject(classVersion, forKey:  "classVersion")
+        coder.encodeObject(blockHeight, forKey: "blockHeight")
+        coder.encodeObject(exchangeRate, forKey: "exchangeRate")
+        coder.encodeObject(exchangeRateCurrency, forKey: "exchangeRateCurrency")
+        coder.encodeObject(confirmations, forKey: "confirmations")
+        coder.encodeObject(size, forKey: "size")
+        coder.encodeObject(firstConfirmation, forKey: "firstConfirmation")
+    }
+}
+
+@objc public class BRTxMetadataObject: BRKVStoreObject {
+    var blockHeight: Int {
+        get { return _meta.blockHeight }
+        set(v) { _meta.blockHeight = v }
+    }
+    var exchangeRate: Int {
+        get { return _meta.exchangeRate }
+        set(v) { _meta.exchangeRate = v }
+    }
+    var exchangeRateCurrency: String {
+        get { return _meta.exchangeRateCurrency }
+        set(v) { _meta.exchangeRateCurrency = v }
+    }
+    var confirmations: Int {
+        get { return _meta.confirmations }
+        set(v) { _meta.confirmations = v }
+    }
+    var size: Int {
+        get { return _meta.size }
+        set(v) { _meta.size = v }
+    }
+    var firstConfirmation: NSDate {
+        get { return _meta.firstConfirmation }
+        set(v) { _meta.firstConfirmation = v }
+    }
+    
+    // this is get and set by the `data` accessor
+    private var _meta: _TXMetadata!
+    
+    public override var data: NSData {
+        get {
+            return NSKeyedArchiver.archivedDataWithRootObject(_meta)
+        }
+        set(v) {
+            _meta = (NSKeyedUnarchiver.unarchiveObjectWithData(v) as? _TXMetadata) ?? _TXMetadata()
+        }
+    }
+    
+    /// Find metadata object based on the txHash
+    public init?(txHash: NSData, store: BRReplicatedKVStore) {
+        var sha = txHash.SHA256()
+        let txHashHash = NSData(bytes: &sha, length: sizeof(UInt256))
+        let key = "txm-\(txHashHash.hexString)"
+        var ver: UInt64
+        var date: NSDate
+        var del: Bool
+        var bytes: [UInt8]
+        do {
+            (ver, date, del, bytes) = try store.get(key)
+        } catch let e {
+            print("Unable to initialize BRTxMetadataObject: \(e)")
+            return nil
+        }
+        let bytesDat = NSData(bytes: &bytes, length: bytes.count)
+        super.init(key: key, version: ver, lastModified: date, deleted: del, data: bytesDat)
+    }
+    
+    /// Create new transaction metadata
+    public init(transaction: BRTransaction) {
+        var sha = NSData(bytes: &transaction.txHash, length: sizeof(UInt256)).SHA256()
+        let txHashHash = NSData(bytes: &sha, length: sizeof(UInt256))
+        let k = "txm-\(txHashHash.hexString)"
+        super.init(key: k, version: 0, lastModified: NSDate(), deleted: false, data: NSData())
+    }
+}

--- a/BreadWallet/BRKVStoreObjects.swift
+++ b/BreadWallet/BRKVStoreObjects.swift
@@ -36,7 +36,6 @@ import Foundation
     var blockHeight: Int = 0
     var exchangeRate: Int = 0
     var exchangeRateCurrency: String = ""
-    var confirmations: Int = 0
     var size: Int = 0
     var created: NSDate = NSDate.zeroValue()
     var firstConfirmation: NSDate = NSDate.zeroValue()
@@ -50,7 +49,6 @@ import Foundation
         blockHeight = decoder.decode("bh")
         exchangeRate = decoder.decode("er")
         exchangeRateCurrency = decoder.decode("erc")
-        confirmations = decoder.decode("conf")
         size = decoder.decode("s")
         firstConfirmation = decoder.decode("fconf")
         created = decoder.decode("c")
@@ -62,7 +60,6 @@ import Foundation
         coder.encode(blockHeight, key: "bh")
         coder.encode(exchangeRate, key: "er")
         coder.encode(exchangeRateCurrency, key: "erc")
-        coder.encode(confirmations, key: "conf")
         coder.encode(size, key: "s")
         coder.encode(firstConfirmation, key: "fconf")
         coder.encode(created, key: "c")
@@ -105,7 +102,6 @@ import Foundation
         blockHeight =           s.blockHeight
         exchangeRate =          s.exchangeRate
         exchangeRateCurrency =  s.exchangeRateCurrency
-        confirmations =         s.confirmations
         size =                  s.size
         firstConfirmation =     s.firstConfirmation
         created =               s.created

--- a/BreadWallet/BRKey.h
+++ b/BreadWallet/BRKey.h
@@ -58,7 +58,7 @@ int BRSecp256k1PointMul(BRECPoint * _Nonnull p, const UInt256 * _Nonnull i);
 @property (nullable, nonatomic, readonly) NSData *publicKey;
 @property (nullable, nonatomic, readonly) NSString *address;
 @property (nonatomic, readonly) UInt160 hash160;
-@property (nonatomic, readonly) UInt256 const * _Nullable secretKey;
+@property (nonatomic, readonly, nullable) const UInt256 *secretKey;
 
 + (nullable instancetype)keyWithPrivateKey:(nonnull NSString *)privateKey;
 + (nullable instancetype)keyWithSecret:(UInt256)secret compressed:(BOOL)compressed;

--- a/BreadWallet/BRKey.m
+++ b/BreadWallet/BRKey.m
@@ -255,7 +255,7 @@ int BRSecp256k1PointMul(BRECPoint *p, const UInt256 *i)
     return self.publicKey.hash160;
 }
 
-- (UInt256 const * _Nullable)secretKey
+- (const UInt256 *)secretKey
 {
     return &_seckey;
 }

--- a/BreadWallet/BRReplicatedKVStore.swift
+++ b/BreadWallet/BRReplicatedKVStore.swift
@@ -780,7 +780,6 @@ extension NSDate {
     init(key: String, version: UInt64, lastModified: NSDate, deleted: Bool, data: NSData) {
         self.version = version
         self.key = key
-        self.version = version
         self.lastModified = lastModified
         self.deleted = deleted
         self.data = data

--- a/BreadWallet/BRReplicatedKVStore.swift
+++ b/BreadWallet/BRReplicatedKVStore.swift
@@ -758,16 +758,6 @@ public class BRReplicatedKVStore: NSObject {
     }
 }
 
-extension NSDate {
-    static func withMsTimestamp(ms: UInt64) -> NSDate {
-        return NSDate(timeIntervalSince1970: Double(ms) / 1000.0)
-    }
-    
-    func msTimestamp() -> UInt64 {
-        return UInt64((self.timeIntervalSince1970 < 0 ? 0 : self.timeIntervalSince1970) * 1000.0)
-    }
-}
-
 // MARK: - Objective-C compatability layer
 
 @objc public class BRKVStoreObject: NSObject {

--- a/BreadWallet/Extensions.swift
+++ b/BreadWallet/Extensions.swift
@@ -26,7 +26,7 @@
 import Foundation
 
 
-extension String {
+public extension String {
     func md5() -> String {
         let data = (self as NSString).dataUsingEncoding(NSUTF8StringEncoding)!
         let result = NSMutableData(length: Int(128/8))!
@@ -87,7 +87,7 @@ var BZCompressionBufferSize: UInt32 = 1024
 var BZDefaultBlockSize: Int32 = 7
 var BZDefaultWorkFactor: Int32 = 100
 
-extension NSData {
+public extension NSData {
     var hexString : String {
         let buf = UnsafePointer<UInt8>(bytes)
         let charA = UInt8(UnicodeScalar("a").value)
@@ -173,9 +173,17 @@ extension NSData {
     }
 }
 
-// this is lifted from: https://github.com/Fykec/NSDate-RFC1123/blob/master/NSDate%2BRFC1123.swift
-// Copyright © 2015 Foster Yin. All rights reserved.
-extension NSDate {
+public extension NSDate {
+    static func withMsTimestamp(ms: UInt64) -> NSDate {
+        return NSDate(timeIntervalSince1970: Double(ms) / 1000.0)
+    }
+    
+    func msTimestamp() -> UInt64 {
+        return UInt64((self.timeIntervalSince1970 < 0 ? 0 : self.timeIntervalSince1970) * 1000.0)
+    }
+
+    // this is lifted from: https://github.com/Fykec/NSDate-RFC1123/blob/master/NSDate%2BRFC1123.swift
+    // Copyright © 2015 Foster Yin. All rights reserved.
     private static func cachedThreadLocalObjectWithKey<T: AnyObject>(key: String, create: () -> T) -> T {
         let threadDictionary = NSThread.currentThread().threadDictionary
         if let cachedObject = threadDictionary[key] as! T? {

--- a/BreadWallet/Extensions.swift
+++ b/BreadWallet/Extensions.swift
@@ -83,6 +83,27 @@ extension String {
     }
 }
 
+extension NSData {
+    var hexString : String {
+        let buf = UnsafePointer<UInt8>(bytes)
+        let charA = UInt8(UnicodeScalar("a").value)
+        let char0 = UInt8(UnicodeScalar("0").value)
+        
+        func itoh(i: UInt8) -> UInt8 {
+            return (i > 9) ? (charA + i - 10) : (char0 + i)
+        }
+        
+        let p = UnsafeMutablePointer<UInt8>.alloc(length * 2)
+        
+        for i in 0..<length {
+            p[i*2] = itoh((buf[i] >> 4) & 0xF)
+            p[i*2+1] = itoh(buf[i] & 0xF)
+        }
+        
+        return NSString(bytesNoCopy: p, length: length*2, encoding: NSUTF8StringEncoding, freeWhenDone: true) as! String
+    }
+}
+
 // this is lifted from: https://github.com/Fykec/NSDate-RFC1123/blob/master/NSDate%2BRFC1123.swift
 // Copyright © 2015 Foster Yin. All rights reserved.
 extension NSDate {

--- a/BreadWallet/NSData+Bitcoin.h
+++ b/BreadWallet/NSData+Bitcoin.h
@@ -154,3 +154,10 @@ size_t chacha20Poly1305AEADDecrypt(void *_Nullable out, size_t outLen, const voi
 - (NSString *_Nonnull)base58String;
 
 @end
+
+
+@interface NSValue (Utils)
+
++ (nonnull instancetype)valueWithUInt256:(UInt256)uint;
+
+@end

--- a/BreadWallet/NSData+Bitcoin.m
+++ b/BreadWallet/NSData+Bitcoin.m
@@ -831,3 +831,13 @@ size_t chacha20Poly1305AEADDecrypt(void *out, size_t outLen, const void *key32, 
 }
 
 @end
+
+
+@implementation NSValue (Utils)
+
++ (instancetype)valueWithUInt256:(UInt256)uint
+{
+    return [NSValue value:uint.u8 withObjCType:@encode(UInt256)];
+}
+
+@end

--- a/BreadWalletTests/BRCodingTests.swift
+++ b/BreadWalletTests/BRCodingTests.swift
@@ -1,0 +1,57 @@
+//
+//  BRCodingTests.swift
+//  BreadWallet
+//
+//  Created by Samuel Sutch on 8/14/16.
+//  Copyright © 2016 Aaron Voisine. All rights reserved.
+//
+
+import XCTest
+@testable import breadwallet
+
+class TestObject: BRCoding {
+    var string: String
+    var int: Int
+    var date: NSDate
+    
+    init(string: String, int: Int, date: NSDate) {
+        self.string = string
+        self.int = int
+        self.date = date
+    }
+    
+    required init?(coder decoder: BRCoder) {
+        string = decoder.decode("string")
+        int = decoder.decode("int")
+        date = decoder.decode("date")
+    }
+    
+    func encode(coder: BRCoder) {
+        coder.encode(string, key: "string")
+        coder.encode(int, key: "int")
+        coder.encode(date, key: "date")
+    }
+}
+
+class BRCodingTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testBasicEncodeAndDecode() {
+        let orig = TestObject(string: "hello", int: 823483, date: NSDate(timeIntervalSince1970: 872347))
+        let dat = BRKeyedArchiver.archivedDataWithRootObject(orig)
+        
+        guard let new: TestObject = BRKeyedUnarchiver.unarchiveObjectWithData(dat) else {
+            XCTFail("unarchived a nil object")
+            return
+        }
+        XCTAssertEqual(orig.string, new.string)
+        XCTAssertEqual(orig.int, new.int)
+        XCTAssertEqual(orig.date, new.date)
+    }
+}

--- a/BreadWalletTests/BRKVStoreObjectsTests.swift
+++ b/BreadWalletTests/BRKVStoreObjectsTests.swift
@@ -1,0 +1,36 @@
+//
+//  BRKVStoreObjectsTests.swift
+//  BreadWallet
+//
+//  Created by Samuel Sutch on 8/14/16.
+//  Copyright © 2016 Aaron Voisine. All rights reserved.
+//
+
+import XCTest
+@testable import breadwallet
+
+class BRKVStoreObjectsTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measureBlock {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/BreadWalletTests/BRKVStoreObjectsTests.swift
+++ b/BreadWalletTests/BRKVStoreObjectsTests.swift
@@ -21,6 +21,9 @@ class BRKVStoreObjectsTests: XCTestCase {
     }
     
     override func tearDown() {
+        try! store.rmdb()
+        store = nil
+        adaptor = nil
         super.tearDown()
     }
 

--- a/BreadWalletTests/BRReplicatedKVStoreTests.swift
+++ b/BreadWalletTests/BRReplicatedKVStoreTests.swift
@@ -15,11 +15,6 @@ class BRReplicatedKVStoreTestAdapter: BRRemoteKVStoreAdaptor {
     
     init(testCase: XCTestCase) {
         self.testCase = testCase
-        db["hello"] = (1, NSDate(), [0, 1], false)
-        db["removed"] = (2, NSDate(), [0, 2], true)
-        for i in 1...20 {
-            db["testkey-\(i)"] = (1, NSDate(), [0, UInt8(i + 2)], false)
-        }
     }
     
     func keys(completionFunc: ([(String, UInt64, NSDate, BRRemoteKVStoreError?)], BRRemoteKVStoreError?) -> ()) {
@@ -99,6 +94,11 @@ class BRReplicatedKVStoreTest: XCTestCase {
     override func setUp() {
         super.setUp()
         adapter = BRReplicatedKVStoreTestAdapter(testCase: self)
+        adapter.db["hello"] = (1, NSDate(), [0, 1], false)
+        adapter.db["removed"] = (2, NSDate(), [0, 2], true)
+        for i in 1...20 {
+            adapter.db["testkey-\(i)"] = (1, NSDate(), [0, UInt8(i + 2)], false)
+        }
         store = try! BRReplicatedKVStore(encryptionKey: key, remoteAdaptor: adapter)
         store.encryptedReplication = false
     }

--- a/BreadWalletTests/NSDataExtensionTests.swift
+++ b/BreadWalletTests/NSDataExtensionTests.swift
@@ -1,0 +1,36 @@
+//
+//  NSDataExtensionTests.swift
+//  BreadWallet
+//
+//  Created by Samuel Sutch on 8/14/16.
+//  Copyright © 2016 Aaron Voisine. All rights reserved.
+//
+
+import XCTest
+@testable import breadwallet
+
+class NSDataExtensionTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testRoundTrip() {
+        for _ in 0..<10 {
+            let randomData = (1...7321).map{_ in UInt8(arc4random_uniform(0x30))}
+            let data = NSData(bytes: randomData, length: randomData.count)
+            guard let compressed = data.bzCompressedData else {
+                XCTFail("compressed data was nil")
+                return
+            }
+            guard let decompressed = NSData(bzCompressedData: compressed) else {
+                XCTFail("decompressed data was nil")
+                return
+            }
+            XCTAssertEqual(data.hexString, decompressed.hexString)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a simple `BRTxMetadataObject` class which can be used from objective-c to save metadata about a transaction. It utilizes a new cross-platform encoding (bz-compressed json) with an API that mimics NSCoding (see BRCoding.swift). Tests are included for for both BRCoding and BRTxMetadataObject.

Note that as of now the BRTxMetadataObject is _not_ used (expecting @voisine to add support for it where he sees fit).