### PR TITLE
run updatePlatform in the background during foreground or in BRRootVewController

### DIFF
--- a/BreadWallet/BRAPIClient.swift
+++ b/BreadWallet/BRAPIClient.swift
@@ -484,7 +484,7 @@ func buildRequestSigningString(_ r: URLRequest) -> String {
         return "ff:\(name)"
     }
     
-    open func updateFeatureFlags() {
+    open func updateFeatureFlags(onComplete: @escaping () -> Void) {
         var authenticated = false
         var furl = "/anybody/features"
         // only use authentication if the user has previously used authenticated services
@@ -495,6 +495,8 @@ func buildRequestSigningString(_ r: URLRequest) -> String {
         let req = URLRequest(url: url(furl))
         dataTaskWithRequest(req, authenticated: authenticated) { (data, resp, err) in
             if let resp = resp, let data = data {
+                let jsonString = String(data: data, encoding: .utf8)
+                self.log("got features data = \(String(describing: jsonString))")
                 if resp.statusCode == 200 {
                     let defaults = UserDefaults.standard
                     do {
@@ -516,6 +518,7 @@ func buildRequestSigningString(_ r: URLRequest) -> String {
             } else {
                 self.log("error fetching features: \(String(describing: err))")
             }
+            onComplete()
         }.resume()
     }
     

--- a/BreadWallet/BRAppDelegate.h
+++ b/BreadWallet/BRAppDelegate.h
@@ -33,5 +33,6 @@
 @property (strong, nonatomic) UIWindow *window;
 
 - (void)registerForPushNotifications;
+- (void)updatePlatformOnComplete:(void (^)(void))onComplete;
 
 @end

--- a/BreadWallet/BRRootViewController.m
+++ b/BreadWallet/BRRootViewController.m
@@ -460,6 +460,7 @@
     else {
         if (_balance == UINT64_MAX && [defs objectForKey:BALANCE_KEY]) self.balance = [defs doubleForKey:BALANCE_KEY];
         self.splash.hidden = YES;
+        
         self.navigationController.navigationBar.hidden = NO;
         self.pageViewController.view.alpha = 1.0;
         [self.receiveViewController updateAddress];
@@ -495,12 +496,17 @@
                 [self.sendViewController handleFile:self.file];
                 self.file = nil;
             }
-            else if (! self.showTips &&
-                     [[NSUserDefaults standardUserDefaults] boolForKey:@"has_alerted_buy_bitcoin"] == NO &&
-                     [WKWebView class] && [[BRAPIClient sharedClient] featureEnabled:BRFeatureFlagsBuyBitcoin]) {
-                [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"has_alerted_buy_bitcoin"];
-                [self showBuyAlert];
-            }
+            
+            BRAppDelegate *del = (BRAppDelegate *)[UIApplication sharedApplication].delegate;
+            [del updatePlatformOnComplete:^{
+                NSLog(@"[BRRootViewController] updatePlatform completed!");
+                if (! self.showTips &&
+                    [[NSUserDefaults standardUserDefaults] boolForKey:@"has_alerted_buy_bitcoin"] == NO
+                    && [WKWebView class] && [[BRAPIClient sharedClient] featureEnabled:BRFeatureFlagsBuyBitcoin]) {
+                    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"has_alerted_buy_bitcoin"];
+                    [self showBuyAlert];
+                }
+            }];
         }
     }
 }


### PR DESCRIPTION
this ensures that updatePlatform is called on new wallets after the
authentication has become available. move updatePlatform out of
applicationDidBecomeActive and into applicationWillEnterForeground
so it is not called duplicate times on launch